### PR TITLE
Remove invalid `lim` preferred name

### DIFF
--- a/data/112/533/149/3/1125331493.geojson
+++ b/data/112/533/149/3/1125331493.geojson
@@ -19,9 +19,6 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
-    "name:lim_x_preferred":[
-        "http://en.wikipedia.org/wiki/Narsdorf"
-    ],
     "qs_pg:aaroncc":"DE",
     "qs_pg:gn_country":"DE",
     "qs_pg:gn_fcode":"ADM4",


### PR DESCRIPTION
`lim`, which corresponds to the [Limburgish](https://en.wikipedia.org/wiki/Limburgish) language spoken in parts of Belgium and the Netherlands, was listed as having a translation for this locality. The translation was just a wikipedia URL, so clearly invalid.