### PR TITLE
Updated records on the border of the Netherlands

### DIFF
--- a/data/137/778/599/1/1377785991.geojson
+++ b/data/137/778/599/1/1377785991.geojson
@@ -31,7 +31,8 @@
         102191581,
         404473841,
         85633337,
-        1310497403
+        101807185,
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -43,16 +44,17 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404473841,
-            "locality_id":1310497403,
+            "locality_id":101807185,
             "neighbourhood_id":1377785991,
             "region_id":85687045
         }
     ],
     "wof:id":1377785991,
-    "wof:lastmodified":1558386537,
+    "wof:lastmodified":1559595858,
     "wof:name":"Freiheit",
-    "wof:parent_id":404473841,
+    "wof:parent_id":101807185,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],

--- a/data/139/360/155/1/1393601551.geojson
+++ b/data/139/360/155/1/1393601551.geojson
@@ -31,7 +31,8 @@
         102191581,
         404474689,
         85633337,
-        1259870879
+        1158783463,
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -43,16 +44,17 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404474689,
-            "locality_id":1259870879,
+            "locality_id":1158783463,
             "neighbourhood_id":1393601551,
             "region_id":85687043
         }
     ],
     "wof:id":1393601551,
-    "wof:lastmodified":1558385393,
+    "wof:lastmodified":1559595908,
     "wof:name":"Feldhuisen",
-    "wof:parent_id":404474689,
+    "wof:parent_id":1158783463,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],

--- a/data/139/363/690/3/1393636903.geojson
+++ b/data/139/363/690/3/1393636903.geojson
@@ -31,7 +31,8 @@
         102191581,
         404474665,
         85633337,
-        1260173849
+        101856055,
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -43,16 +44,17 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404474665,
-            "locality_id":1260173849,
+            "locality_id":101856055,
             "neighbourhood_id":1393636903,
             "region_id":85687045
         }
     ],
     "wof:id":1393636903,
-    "wof:lastmodified":1558385497,
+    "wof:lastmodified":1559595967,
     "wof:name":"Frensdorferhaar",
-    "wof:parent_id":404474665,
+    "wof:parent_id":101856055,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],

--- a/data/139/365/759/7/1393657597.geojson
+++ b/data/139/365/759/7/1393657597.geojson
@@ -34,9 +34,11 @@
     "wof:belongsto":[
         85687033,
         102191581,
+        1158818153,
         404474489,
         85633337,
-        1360205573
+        101839255,
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -48,16 +50,18 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404474489,
-            "locality_id":1360205573,
+            "locality_id":101839255,
+            "macrohood_id":1158818153,
             "neighbourhood_id":1393657597,
             "region_id":85687033
         }
     ],
     "wof:id":1393657597,
-    "wof:lastmodified":1558387386,
+    "wof:lastmodified":1559595968,
     "wof:name":"Nievelstein",
-    "wof:parent_id":404474489,
+    "wof:parent_id":1158818153,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],

--- a/data/857/971/27/85797127.geojson
+++ b/data/857/971/27/85797127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
-    "geom:area_square_m":8311970.226937,
+    "geom:area_square_m":0.0,
     "geom:bbox":"6.06612,50.855594,6.06612,50.855594",
     "geom:latitude":50.855594,
     "geom:longitude":6.06612,
@@ -85,7 +85,8 @@
         1158818155,
         404474489,
         85633337,
-        101839255
+        101839255,
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -100,6 +101,7 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404474489,
             "locality_id":101839255,
             "macrohood_id":1158818155,
@@ -111,7 +113,7 @@
     "wof:lang":[
         "dut"
     ],
-    "wof:lastmodified":1531861870,
+    "wof:lastmodified":1559595824,
     "wof:name":"Bleijerheide",
     "wof:parent_id":1158818155,
     "wof:placetype":"neighbourhood",

--- a/data/857/977/21/85797721.geojson
+++ b/data/857/977/21/85797721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
-    "geom:area_square_m":9328288.587636,
+    "geom:area_square_m":0.0,
     "geom:bbox":"6.076955,50.867449,6.076955,50.867449",
     "geom:latitude":50.867449,
     "geom:longitude":6.076955,
@@ -101,7 +101,8 @@
         1158818155,
         404474489,
         85633337,
-        101839255
+        101839255,
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -116,6 +117,7 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404474489,
             "locality_id":101839255,
             "macrohood_id":1158818155,
@@ -127,7 +129,7 @@
     "wof:lang":[
         "dut"
     ],
-    "wof:lastmodified":1531861899,
+    "wof:lastmodified":1559595826,
     "wof:name":"Holz",
     "wof:parent_id":1158818155,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
This PR contains "leftover" records in Germany that were updated during PIP work in the Netherlands repo. Each of these six records need either:

- Better, more accurate geometries
- an is_current = 0 flag and deprecated date

Then, they need their hierarchies rebuilt.

See: https://github.com/whosonfirst-data/whosonfirst-data-admin-nl/pull/1