### PR TITLE
Updated name in DE neighbourhood

### DIFF
--- a/data/139/362/758/5/1393627585.geojson
+++ b/data/139/362/758/5/1393627585.geojson
@@ -18,6 +18,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Hofolding"
+    ],
+    "name:eng_x_variant":[
+        "H\u00f6lding"
+    ],
     "qs_pg:aaroncc":"DE",
     "qs_pg:gn_country":"DE",
     "qs_pg:gn_fcode":"PPL",
@@ -41,13 +47,13 @@
     "woe:name_adm1":"Bayern",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        85682571,
         102191581,
         85633111,
         1377692729,
         404227567,
         101786655,
-        102063273
+        102063273,
+        85682571
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -71,8 +77,8 @@
         }
     ],
     "wof:id":1393627585,
-    "wof:lastmodified":1559005965,
-    "wof:name":"H\u00f6lding",
+    "wof:lastmodified":1561493428,
+    "wof:name":"Hofolding",
     "wof:parent_id":101786655,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1648

- Updates `wof:name` value
- Adds `name:*` properties

No PIP required, can merge once approved.