### PR TITLE
Update Berlin records and descendants

### DIFF
--- a/data/101/909/779/101909779.geojson
+++ b/data/101/909/779/101909779.geojson
@@ -15,10 +15,10 @@
     "gn:gn_pop":3442675,
     "gn:population":3375222,
     "iso:country":"DE",
-    "lbl:latitude":52.39738,
-    "lbl:longitude":13.228406,
-    "mps:latitude":52.39738,
-    "mps:longitude":13.228406,
+    "lbl:latitude":52.524932,
+    "lbl:longitude":13.407032,
+    "mps:latitude":52.524932,
+    "mps:longitude":13.407032,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "name:abk_x_preferred":[
@@ -824,6 +824,8 @@
     "qs_pg:pop_sr":12,
     "qs_pg:qs_id":630199,
     "qs_pg:qs_pg_placetype":"localadmin",
+    "reversegeo:latitude":52.524932,
+    "reversegeo:longitude":13.407032,
     "src:geom":"de-bkg",
     "src:geom_alt":[
         "quattroshapes"
@@ -831,11 +833,10 @@
     "src:lbl:centroid":"mapshaper",
     "src:population":"geonames",
     "wof:belongsto":[
-        85682553,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
-        102063937
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -848,16 +849,15 @@
         {
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":101909779,
-    "wof:lastmodified":1563262630,
+    "wof:lastmodified":1563999806,
     "wof:name":"Berlin",
-    "wof:parent_id":1377683779,
+    "wof:parent_id":1377694153,
     "wof:placetype":"locality",
     "wof:population":3375222,
     "wof:population_rank":12,

--- a/data/110/881/018/7/1108810187.geojson
+++ b/data/110/881/018/7/1108810187.geojson
@@ -32,12 +32,11 @@
     "wof:belongsto":[
         420784293,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815545,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -48,16 +47,15 @@
             "borough_id":1108815545,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810187,
             "neighbourhood_id":420784293,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810187,
-    "wof:lastmodified":1559008564,
+    "wof:lastmodified":1563999802,
     "wof:name":"Alexanderplatz",
     "wof:parent_id":420784293,
     "wof:placetype":"microhood",

--- a/data/110/881/018/9/1108810189.geojson
+++ b/data/110/881/018/9/1108810189.geojson
@@ -32,12 +32,11 @@
     "wof:belongsto":[
         420784273,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815541,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -48,16 +47,15 @@
             "borough_id":1108815541,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810189,
             "neighbourhood_id":420784273,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810189,
-    "wof:lastmodified":1559008564,
+    "wof:lastmodified":1563999805,
     "wof:name":"Marzahn-Nord",
     "wof:parent_id":420784273,
     "wof:placetype":"microhood",

--- a/data/110/881/019/1/1108810191.geojson
+++ b/data/110/881/019/1/1108810191.geojson
@@ -29,12 +29,11 @@
     "wof:belongsto":[
         85900125,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815551,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -45,16 +44,15 @@
             "borough_id":1108815551,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810191,
             "neighbourhood_id":85900125,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810191,
-    "wof:lastmodified":1559008564,
+    "wof:lastmodified":1563999802,
     "wof:name":"Cite Pasteur",
     "wof:parent_id":85900125,
     "wof:placetype":"microhood",

--- a/data/110/881/019/3/1108810193.geojson
+++ b/data/110/881/019/3/1108810193.geojson
@@ -29,12 +29,11 @@
     "wof:belongsto":[
         420784293,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815545,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -45,16 +44,15 @@
             "borough_id":1108815545,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810193,
             "neighbourhood_id":420784293,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810193,
-    "wof:lastmodified":1559008559,
+    "wof:lastmodified":1563999799,
     "wof:name":"Gendarmenmarkt",
     "wof:parent_id":420784293,
     "wof:placetype":"microhood",

--- a/data/110/881/019/5/1108810195.geojson
+++ b/data/110/881/019/5/1108810195.geojson
@@ -29,12 +29,11 @@
     "wof:belongsto":[
         420784293,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815545,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -45,16 +44,15 @@
             "borough_id":1108815545,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810195,
             "neighbourhood_id":420784293,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810195,
-    "wof:lastmodified":1559008560,
+    "wof:lastmodified":1563999802,
     "wof:name":"Museuminsel",
     "wof:parent_id":420784293,
     "wof:placetype":"microhood",

--- a/data/110/881/019/9/1108810199.geojson
+++ b/data/110/881/019/9/1108810199.geojson
@@ -29,12 +29,11 @@
     "wof:belongsto":[
         420784293,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815545,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -45,16 +44,15 @@
             "borough_id":1108815545,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810199,
             "neighbourhood_id":420784293,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810199,
-    "wof:lastmodified":1559008562,
+    "wof:lastmodified":1563999804,
     "wof:name":"Scheunenviertel",
     "wof:parent_id":420784293,
     "wof:placetype":"microhood",

--- a/data/110/881/020/1/1108810201.geojson
+++ b/data/110/881/020/1/1108810201.geojson
@@ -36,12 +36,11 @@
     "wof:belongsto":[
         420784269,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815541,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -52,16 +51,15 @@
             "borough_id":1108815541,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810201,
             "neighbourhood_id":420784269,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810201,
-    "wof:lastmodified":1559008559,
+    "wof:lastmodified":1563999799,
     "wof:name":"Biesdorf-S\u00fcd",
     "wof:parent_id":420784269,
     "wof:placetype":"microhood",

--- a/data/110/881/020/3/1108810203.geojson
+++ b/data/110/881/020/3/1108810203.geojson
@@ -33,12 +33,11 @@
     "wof:belongsto":[
         420784269,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815541,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -49,16 +48,15 @@
             "borough_id":1108815541,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810203,
             "neighbourhood_id":420784269,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810203,
-    "wof:lastmodified":1559008562,
+    "wof:lastmodified":1563999804,
     "wof:name":"Biesdorf-Nord",
     "wof:parent_id":420784269,
     "wof:placetype":"microhood",

--- a/data/110/881/020/7/1108810207.geojson
+++ b/data/110/881/020/7/1108810207.geojson
@@ -40,12 +40,11 @@
     "wof:belongsto":[
         1108815531,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815547,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -56,16 +55,15 @@
             "borough_id":1108815547,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810207,
             "neighbourhood_id":1108815531,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810207,
-    "wof:lastmodified":1559008559,
+    "wof:lastmodified":1563999799,
     "wof:name":"Buckow I",
     "wof:parent_id":1108815531,
     "wof:placetype":"microhood",

--- a/data/110/881/020/9/1108810209.geojson
+++ b/data/110/881/020/9/1108810209.geojson
@@ -40,12 +40,11 @@
     "wof:belongsto":[
         1108815531,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815547,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -56,16 +55,15 @@
             "borough_id":1108815547,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810209,
             "neighbourhood_id":1108815531,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810209,
-    "wof:lastmodified":1559008559,
+    "wof:lastmodified":1563999799,
     "wof:name":"Buckow II",
     "wof:parent_id":1108815531,
     "wof:placetype":"microhood",

--- a/data/110/881/021/1/1108810211.geojson
+++ b/data/110/881/021/1/1108810211.geojson
@@ -36,12 +36,11 @@
     "wof:belongsto":[
         420784341,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815555,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -52,16 +51,15 @@
             "borough_id":1108815555,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810211,
             "neighbourhood_id":420784341,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810211,
-    "wof:lastmodified":1559008561,
+    "wof:lastmodified":1563999803,
     "wof:name":"D\u00fcppel",
     "wof:parent_id":420784341,
     "wof:placetype":"microhood",

--- a/data/110/881/021/3/1108810213.geojson
+++ b/data/110/881/021/3/1108810213.geojson
@@ -33,12 +33,11 @@
     "wof:belongsto":[
         85900231,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815535,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -49,16 +48,15 @@
             "borough_id":1108815535,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810213,
             "neighbourhood_id":85900231,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810213,
-    "wof:lastmodified":1559008562,
+    "wof:lastmodified":1563999801,
     "wof:name":"Eichkamp",
     "wof:parent_id":85900231,
     "wof:placetype":"microhood",

--- a/data/110/881/021/7/1108810217.geojson
+++ b/data/110/881/021/7/1108810217.geojson
@@ -33,12 +33,11 @@
     "wof:belongsto":[
         420784225,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815553,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -49,16 +48,15 @@
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810217,
             "neighbourhood_id":420784225,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810217,
-    "wof:lastmodified":1559008563,
+    "wof:lastmodified":1563999801,
     "wof:name":"Gartenfeld",
     "wof:parent_id":420784225,
     "wof:placetype":"microhood",

--- a/data/110/881/022/1/1108810221.geojson
+++ b/data/110/881/022/1/1108810221.geojson
@@ -32,12 +32,11 @@
     "wof:belongsto":[
         85899697,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815553,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -48,16 +47,15 @@
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810221,
             "neighbourhood_id":85899697,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810221,
-    "wof:lastmodified":1559008561,
+    "wof:lastmodified":1563999800,
     "wof:name":"Gross-Glienicke",
     "wof:parent_id":85899697,
     "wof:placetype":"microhood",

--- a/data/110/881/022/3/1108810223.geojson
+++ b/data/110/881/022/3/1108810223.geojson
@@ -33,12 +33,11 @@
     "wof:belongsto":[
         420784381,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815559,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -49,16 +48,15 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810223,
             "neighbourhood_id":420784381,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810223,
-    "wof:lastmodified":1559008561,
+    "wof:lastmodified":1563999803,
     "wof:name":"Hirschgarten",
     "wof:parent_id":420784381,
     "wof:placetype":"microhood",

--- a/data/110/881/022/5/1108810225.geojson
+++ b/data/110/881/022/5/1108810225.geojson
@@ -33,12 +33,11 @@
     "wof:belongsto":[
         420784311,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815553,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -49,16 +48,15 @@
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810225,
             "neighbourhood_id":420784311,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810225,
-    "wof:lastmodified":1559008563,
+    "wof:lastmodified":1563999801,
     "wof:name":"Johannesstift",
     "wof:parent_id":420784311,
     "wof:placetype":"microhood",

--- a/data/110/881/022/7/1108810227.geojson
+++ b/data/110/881/022/7/1108810227.geojson
@@ -39,12 +39,11 @@
     "wof:belongsto":[
         85905659,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815541,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -55,16 +54,15 @@
             "borough_id":1108815541,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810227,
             "neighbourhood_id":85905659,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810227,
-    "wof:lastmodified":1559008559,
+    "wof:lastmodified":1563999800,
     "wof:name":"Kaulsdorf-S\u00fcd",
     "wof:parent_id":85905659,
     "wof:placetype":"microhood",

--- a/data/110/881/022/9/1108810229.geojson
+++ b/data/110/881/022/9/1108810229.geojson
@@ -36,12 +36,11 @@
     "wof:belongsto":[
         420784345,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815555,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -52,16 +51,15 @@
             "borough_id":1108815555,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810229,
             "neighbourhood_id":420784345,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810229,
-    "wof:lastmodified":1559008564,
+    "wof:lastmodified":1563999802,
     "wof:name":"Kohlhasenbr\u00fcck",
     "wof:parent_id":420784345,
     "wof:placetype":"microhood",

--- a/data/110/881/024/3/1108810243.geojson
+++ b/data/110/881/024/3/1108810243.geojson
@@ -33,12 +33,11 @@
     "wof:belongsto":[
         420784327,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815557,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -49,16 +48,15 @@
             "borough_id":1108815557,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810243,
             "neighbourhood_id":420784327,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810243,
-    "wof:lastmodified":1559008565,
+    "wof:lastmodified":1563999802,
     "wof:name":"Lindenhof",
     "wof:parent_id":420784327,
     "wof:placetype":"microhood",

--- a/data/110/881/024/7/1108810247.geojson
+++ b/data/110/881/024/7/1108810247.geojson
@@ -33,12 +33,11 @@
     "wof:belongsto":[
         420784383,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815559,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -49,16 +48,15 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810247,
             "neighbourhood_id":420784383,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810247,
-    "wof:lastmodified":1559008565,
+    "wof:lastmodified":1563999806,
     "wof:name":"Neu Venedig",
     "wof:parent_id":420784383,
     "wof:placetype":"microhood",

--- a/data/110/881/025/3/1108810253.geojson
+++ b/data/110/881/025/3/1108810253.geojson
@@ -36,12 +36,11 @@
     "wof:belongsto":[
         420784241,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815549,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -52,16 +51,15 @@
             "borough_id":1108815549,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108810253,
             "neighbourhood_id":420784241,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108810253,
-    "wof:lastmodified":1559008561,
+    "wof:lastmodified":1563999803,
     "wof:name":"Nordend",
     "wof:parent_id":420784241,
     "wof:placetype":"microhood",

--- a/data/110/881/505/3/1108815053.geojson
+++ b/data/110/881/505/3/1108815053.geojson
@@ -33,12 +33,11 @@
     "wof:belongsto":[
         420784387,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815559,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -49,16 +48,15 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815053,
             "neighbourhood_id":420784387,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815053,
-    "wof:lastmodified":1559008565,
+    "wof:lastmodified":1563999805,
     "wof:name":"Oberspree",
     "wof:parent_id":420784387,
     "wof:placetype":"microhood",

--- a/data/110/881/505/5/1108815055.geojson
+++ b/data/110/881/505/5/1108815055.geojson
@@ -33,12 +33,11 @@
     "wof:belongsto":[
         85900231,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815535,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -49,16 +48,15 @@
             "borough_id":1108815535,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815055,
             "neighbourhood_id":85900231,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815055,
-    "wof:lastmodified":1559008565,
+    "wof:lastmodified":1563999806,
     "wof:name":"Pichelsberg",
     "wof:parent_id":85900231,
     "wof:placetype":"microhood",

--- a/data/110/881/505/9/1108815059.geojson
+++ b/data/110/881/505/9/1108815059.geojson
@@ -36,12 +36,11 @@
     "wof:belongsto":[
         420784285,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815545,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -52,16 +51,15 @@
             "borough_id":1108815545,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815059,
             "neighbourhood_id":420784285,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815059,
-    "wof:lastmodified":1559008561,
+    "wof:lastmodified":1563999803,
     "wof:name":"Pl\u00f6tzensee",
     "wof:parent_id":420784285,
     "wof:placetype":"microhood",

--- a/data/110/881/506/3/1108815063.geojson
+++ b/data/110/881/506/3/1108815063.geojson
@@ -33,12 +33,11 @@
     "wof:belongsto":[
         85900231,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815535,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -49,16 +48,15 @@
             "borough_id":1108815535,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815063,
             "neighbourhood_id":85900231,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815063,
-    "wof:lastmodified":1559008560,
+    "wof:lastmodified":1563999800,
     "wof:name":"Ruhleben",
     "wof:parent_id":85900231,
     "wof:placetype":"microhood",

--- a/data/110/881/506/5/1108815065.geojson
+++ b/data/110/881/506/5/1108815065.geojson
@@ -33,12 +33,11 @@
     "wof:belongsto":[
         420784343,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815555,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -49,16 +48,15 @@
             "borough_id":1108815555,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815065,
             "neighbourhood_id":420784343,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815065,
-    "wof:lastmodified":1559008562,
+    "wof:lastmodified":1563999803,
     "wof:name":"Schlachtensee",
     "wof:parent_id":420784343,
     "wof:placetype":"microhood",

--- a/data/110/881/506/7/1108815067.geojson
+++ b/data/110/881/506/7/1108815067.geojson
@@ -36,12 +36,11 @@
     "wof:belongsto":[
         420784247,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815549,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -52,16 +51,15 @@
             "borough_id":1108815549,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815067,
             "neighbourhood_id":420784247,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815067,
-    "wof:lastmodified":1559008563,
+    "wof:lastmodified":1563999805,
     "wof:name":"Sch\u00f6nholz",
     "wof:parent_id":420784247,
     "wof:placetype":"microhood",

--- a/data/110/881/506/9/1108815069.geojson
+++ b/data/110/881/506/9/1108815069.geojson
@@ -36,12 +36,11 @@
     "wof:belongsto":[
         420784377,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815559,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -52,16 +51,15 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815069,
             "neighbourhood_id":420784377,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815069,
-    "wof:lastmodified":1559008564,
+    "wof:lastmodified":1563999802,
     "wof:name":"Spindlersfeld",
     "wof:parent_id":420784377,
     "wof:placetype":"microhood",

--- a/data/110/881/507/1/1108815071.geojson
+++ b/data/110/881/507/1/1108815071.geojson
@@ -34,12 +34,11 @@
     "wof:belongsto":[
         85899171,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815537,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -50,16 +49,15 @@
             "borough_id":1108815537,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815071,
             "neighbourhood_id":85899171,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815071,
-    "wof:lastmodified":1559008561,
+    "wof:lastmodified":1563999801,
     "wof:name":"Stralau",
     "wof:parent_id":85899171,
     "wof:placetype":"microhood",

--- a/data/110/881/507/7/1108815077.geojson
+++ b/data/110/881/507/7/1108815077.geojson
@@ -36,12 +36,11 @@
     "wof:belongsto":[
         420784333,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815555,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -52,16 +51,15 @@
             "borough_id":1108815555,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815077,
             "neighbourhood_id":420784333,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815077,
-    "wof:lastmodified":1559008565,
+    "wof:lastmodified":1563999806,
     "wof:name":"S\u00fcdende",
     "wof:parent_id":420784333,
     "wof:placetype":"microhood",

--- a/data/110/881/507/9/1108815079.geojson
+++ b/data/110/881/507/9/1108815079.geojson
@@ -33,12 +33,11 @@
     "wof:belongsto":[
         420784309,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815553,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -49,16 +48,15 @@
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815079,
             "neighbourhood_id":420784309,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815079,
-    "wof:lastmodified":1559008563,
+    "wof:lastmodified":1563999805,
     "wof:name":"Tiefwerder",
     "wof:parent_id":420784309,
     "wof:placetype":"microhood",

--- a/data/110/881/508/1/1108815081.geojson
+++ b/data/110/881/508/1/1108815081.geojson
@@ -39,12 +39,11 @@
     "wof:belongsto":[
         420784377,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815559,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -55,16 +54,15 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815081,
             "neighbourhood_id":420784377,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815081,
-    "wof:lastmodified":1559008560,
+    "wof:lastmodified":1563999800,
     "wof:name":"Wendenschlo\u00df",
     "wof:parent_id":420784377,
     "wof:placetype":"microhood",

--- a/data/110/881/508/3/1108815083.geojson
+++ b/data/110/881/508/3/1108815083.geojson
@@ -36,12 +36,11 @@
     "wof:belongsto":[
         420784383,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815559,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -52,16 +51,15 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815083,
             "neighbourhood_id":420784383,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815083,
-    "wof:lastmodified":1559008562,
+    "wof:lastmodified":1563999804,
     "wof:name":"Wilhelmshagen",
     "wof:parent_id":420784383,
     "wof:placetype":"microhood",

--- a/data/110/881/508/5/1108815085.geojson
+++ b/data/110/881/508/5/1108815085.geojson
@@ -33,12 +33,11 @@
     "wof:belongsto":[
         420784377,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815559,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -49,16 +48,15 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815085,
             "neighbourhood_id":420784377,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815085,
-    "wof:lastmodified":1559008563,
+    "wof:lastmodified":1563999805,
     "wof:name":"Wolfsgarten",
     "wof:parent_id":420784377,
     "wof:placetype":"microhood",

--- a/data/110/881/508/7/1108815087.geojson
+++ b/data/110/881/508/7/1108815087.geojson
@@ -33,12 +33,11 @@
     "wof:belongsto":[
         420784269,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815541,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -49,16 +48,15 @@
             "borough_id":1108815541,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815087,
             "neighbourhood_id":420784269,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815087,
-    "wof:lastmodified":1559008560,
+    "wof:lastmodified":1563999800,
     "wof:name":"Wuhlgarten",
     "wof:parent_id":420784269,
     "wof:placetype":"microhood",

--- a/data/110/881/508/9/1108815089.geojson
+++ b/data/110/881/508/9/1108815089.geojson
@@ -36,12 +36,11 @@
     "wof:belongsto":[
         420784387,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815559,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -52,16 +51,15 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815089,
             "neighbourhood_id":420784387,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815089,
-    "wof:lastmodified":1559008560,
+    "wof:lastmodified":1563999800,
     "wof:name":"Wuhlheide",
     "wof:parent_id":420784387,
     "wof:placetype":"microhood",

--- a/data/110/881/512/1/1108815121.geojson
+++ b/data/110/881/512/1/1108815121.geojson
@@ -33,12 +33,11 @@
     "wof:belongsto":[
         420784377,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815559,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -49,16 +48,15 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815121,
             "neighbourhood_id":420784377,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815121,
-    "wof:lastmodified":1559008561,
+    "wof:lastmodified":1563999803,
     "wof:name":"Elsengrund",
     "wof:parent_id":420784377,
     "wof:placetype":"microhood",

--- a/data/110/881/512/3/1108815123.geojson
+++ b/data/110/881/512/3/1108815123.geojson
@@ -36,12 +36,11 @@
     "wof:belongsto":[
         420784265,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815539,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -52,16 +51,15 @@
             "borough_id":1108815539,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815123,
             "neighbourhood_id":420784265,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815123,
-    "wof:lastmodified":1559008562,
+    "wof:lastmodified":1563999804,
     "wof:name":"Falkenh\u00f6he",
     "wof:parent_id":420784265,
     "wof:placetype":"microhood",

--- a/data/110/881/512/5/1108815125.geojson
+++ b/data/110/881/512/5/1108815125.geojson
@@ -36,12 +36,11 @@
     "wof:belongsto":[
         85898965,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815553,
-        102063937,
-        85682553,
+        85682499,
         85899711
     ],
     "wof:breaches":[],
@@ -53,27 +52,25 @@
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815125,
             "neighbourhood_id":85898965,
-            "region_id":85682553
+            "region_id":85682499
         },
         {
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815125,
             "neighbourhood_id":85899711,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815125,
-    "wof:lastmodified":1559008563,
+    "wof:lastmodified":1563999804,
     "wof:name":"Heerstra\u00dfe",
     "wof:parent_id":-3,
     "wof:placetype":"microhood",

--- a/data/110/881/512/7/1108815127.geojson
+++ b/data/110/881/512/7/1108815127.geojson
@@ -36,12 +36,11 @@
     "wof:belongsto":[
         420784383,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815559,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -52,16 +51,15 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815127,
             "neighbourhood_id":420784383,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815127,
-    "wof:lastmodified":1559008564,
+    "wof:lastmodified":1563999805,
     "wof:name":"Hessenwinkel",
     "wof:parent_id":420784383,
     "wof:placetype":"microhood",

--- a/data/110/881/513/1/1108815131.geojson
+++ b/data/110/881/513/1/1108815131.geojson
@@ -36,12 +36,11 @@
     "wof:belongsto":[
         85900021,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815559,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -52,16 +51,15 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815131,
             "neighbourhood_id":85900021,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815131,
-    "wof:lastmodified":1559008560,
+    "wof:lastmodified":1563999802,
     "wof:name":"Karolinenhof",
     "wof:parent_id":85900021,
     "wof:placetype":"microhood",

--- a/data/110/881/513/3/1108815133.geojson
+++ b/data/110/881/513/3/1108815133.geojson
@@ -33,12 +33,11 @@
     "wof:belongsto":[
         420784311,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815553,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -49,16 +48,15 @@
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815133,
             "neighbourhood_id":420784311,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815133,
-    "wof:lastmodified":1559008562,
+    "wof:lastmodified":1563999801,
     "wof:name":"Radeland",
     "wof:parent_id":420784311,
     "wof:placetype":"microhood",

--- a/data/110/881/513/5/1108815135.geojson
+++ b/data/110/881/513/5/1108815135.geojson
@@ -33,12 +33,11 @@
     "wof:belongsto":[
         85900125,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815551,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -49,16 +48,15 @@
             "borough_id":1108815551,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815135,
             "neighbourhood_id":85900125,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815135,
-    "wof:lastmodified":1559008563,
+    "wof:lastmodified":1563999804,
     "wof:name":"Saatwinkel",
     "wof:parent_id":85900125,
     "wof:placetype":"microhood",

--- a/data/110/881/513/9/1108815139.geojson
+++ b/data/110/881/513/9/1108815139.geojson
@@ -34,12 +34,11 @@
     "wof:belongsto":[
         85899275,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815551,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -50,16 +49,15 @@
             "borough_id":1108815551,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815139,
             "neighbourhood_id":85899275,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815139,
-    "wof:lastmodified":1559008564,
+    "wof:lastmodified":1563999801,
     "wof:name":"Schulzendorf",
     "wof:parent_id":85899275,
     "wof:placetype":"microhood",

--- a/data/110/881/514/1/1108815141.geojson
+++ b/data/110/881/514/1/1108815141.geojson
@@ -36,12 +36,11 @@
     "wof:belongsto":[
         420784377,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
         1108815559,
-        102063937,
-        85682553
+        85682499
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -52,16 +51,15 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "microhood_id":1108815141,
             "neighbourhood_id":420784377,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815141,
-    "wof:lastmodified":1559008560,
+    "wof:lastmodified":1563999800,
     "wof:name":"M\u00fcggelhort",
     "wof:parent_id":420784377,
     "wof:placetype":"microhood",

--- a/data/110/881/552/7/1108815527.geojson
+++ b/data/110/881/552/7/1108815527.geojson
@@ -36,13 +36,12 @@
     "ssuberlin:spatial_alias":"Blankenfelde",
     "ssuberlin:spatial_name":"0308",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815549,
-        102063937
+        1108815549
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -56,15 +55,14 @@
             "borough_id":1108815549,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":1108815527,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815527,
-    "wof:lastmodified":1558998775,
+    "wof:lastmodified":1563999780,
     "wof:name":"Blankenfelde",
     "wof:parent_id":1108815549,
     "wof:placetype":"neighbourhood",

--- a/data/110/881/552/9/1108815529.geojson
+++ b/data/110/881/552/9/1108815529.geojson
@@ -54,13 +54,12 @@
     "ssuberlin:spatial_alias":"Dahlem",
     "ssuberlin:spatial_name":"0605",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815555,
-        102063937
+        1108815555
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -74,15 +73,14 @@
             "borough_id":1108815555,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":1108815529,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815529,
-    "wof:lastmodified":1558998775,
+    "wof:lastmodified":1563999780,
     "wof:name":"Dahlem",
     "wof:parent_id":1108815555,
     "wof:placetype":"neighbourhood",

--- a/data/110/881/553/1/1108815531.geojson
+++ b/data/110/881/553/1/1108815531.geojson
@@ -42,13 +42,12 @@
     "ssuberlin:spatial_alias":"Buckow",
     "ssuberlin:spatial_name":"0803",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815547,
-        102063937
+        1108815547
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -62,15 +61,14 @@
             "borough_id":1108815547,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":1108815531,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815531,
-    "wof:lastmodified":1558998776,
+    "wof:lastmodified":1563999780,
     "wof:name":"Buckow",
     "wof:parent_id":1108815547,
     "wof:placetype":"neighbourhood",

--- a/data/110/881/553/3/1108815533.geojson
+++ b/data/110/881/553/3/1108815533.geojson
@@ -48,13 +48,12 @@
     "ssuberlin:spatial_alias":"Karlshorst",
     "ssuberlin:spatial_name":"1102",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815539,
-        102063937
+        1108815539
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -68,15 +67,14 @@
             "borough_id":1108815539,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":1108815533,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815533,
-    "wof:lastmodified":1558998830,
+    "wof:lastmodified":1563999791,
     "wof:name":"Karlshorst",
     "wof:parent_id":1108815539,
     "wof:placetype":"neighbourhood",

--- a/data/110/881/553/5/1108815535.geojson
+++ b/data/110/881/553/5/1108815535.geojson
@@ -30,12 +30,11 @@
     "ssuberlin:spatial_alias":"Charlottenburg-Wilmersdorf",
     "ssuberlin:spatial_name":"04",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
-        101909779,
-        102063937
+        101909779
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -46,14 +45,13 @@
             "borough_id":1108815535,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815535,
-    "wof:lastmodified":1558998007,
+    "wof:lastmodified":1563999773,
     "wof:name":"Charlottenburg-Wilmersdorf",
     "wof:parent_id":101909779,
     "wof:placetype":"borough",

--- a/data/110/881/553/7/1108815537.geojson
+++ b/data/110/881/553/7/1108815537.geojson
@@ -30,12 +30,11 @@
     "ssuberlin:spatial_alias":"Friedrichshain-Kreuzberg",
     "ssuberlin:spatial_name":"02",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
-        101909779,
-        102063937
+        101909779
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -46,14 +45,13 @@
             "borough_id":1108815537,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815537,
-    "wof:lastmodified":1558998009,
+    "wof:lastmodified":1563999776,
     "wof:name":"Friedrichshain-Kreuzberg",
     "wof:parent_id":101909779,
     "wof:placetype":"borough",

--- a/data/110/881/553/9/1108815539.geojson
+++ b/data/110/881/553/9/1108815539.geojson
@@ -30,12 +30,11 @@
     "ssuberlin:spatial_alias":"Lichtenberg",
     "ssuberlin:spatial_name":"11",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
-        101909779,
-        102063937
+        101909779
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -46,14 +45,13 @@
             "borough_id":1108815539,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815539,
-    "wof:lastmodified":1558998007,
+    "wof:lastmodified":1563999773,
     "wof:name":"Lichtenberg",
     "wof:parent_id":101909779,
     "wof:placetype":"borough",

--- a/data/110/881/554/1/1108815541.geojson
+++ b/data/110/881/554/1/1108815541.geojson
@@ -30,12 +30,11 @@
     "ssuberlin:spatial_alias":"Marzahn-Hellersdorf",
     "ssuberlin:spatial_name":"10",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
-        101909779,
-        102063937
+        101909779
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -46,14 +45,13 @@
             "borough_id":1108815541,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815541,
-    "wof:lastmodified":1558998008,
+    "wof:lastmodified":1563999774,
     "wof:name":"Marzahn-Hellersdorf",
     "wof:parent_id":101909779,
     "wof:placetype":"borough",

--- a/data/110/881/554/5/1108815545.geojson
+++ b/data/110/881/554/5/1108815545.geojson
@@ -30,12 +30,11 @@
     "ssuberlin:spatial_alias":"Mitte",
     "ssuberlin:spatial_name":"01",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
-        101909779,
-        102063937
+        101909779
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -46,14 +45,13 @@
             "borough_id":1108815545,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815545,
-    "wof:lastmodified":1558998008,
+    "wof:lastmodified":1563999773,
     "wof:name":"Mitte",
     "wof:parent_id":101909779,
     "wof:placetype":"borough",

--- a/data/110/881/554/7/1108815547.geojson
+++ b/data/110/881/554/7/1108815547.geojson
@@ -30,12 +30,11 @@
     "ssuberlin:spatial_alias":"Neuk\u00f6lln",
     "ssuberlin:spatial_name":"08",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
-        101909779,
-        102063937
+        101909779
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -46,14 +45,13 @@
             "borough_id":1108815547,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815547,
-    "wof:lastmodified":1558998008,
+    "wof:lastmodified":1563999774,
     "wof:name":"Neukolln",
     "wof:parent_id":101909779,
     "wof:placetype":"borough",

--- a/data/110/881/554/9/1108815549.geojson
+++ b/data/110/881/554/9/1108815549.geojson
@@ -30,12 +30,11 @@
     "ssuberlin:spatial_alias":"Pankow",
     "ssuberlin:spatial_name":"03",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
-        101909779,
-        102063937
+        101909779
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -46,14 +45,13 @@
             "borough_id":1108815549,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815549,
-    "wof:lastmodified":1558998008,
+    "wof:lastmodified":1563999774,
     "wof:name":"Pankow",
     "wof:parent_id":101909779,
     "wof:placetype":"borough",

--- a/data/110/881/555/1/1108815551.geojson
+++ b/data/110/881/555/1/1108815551.geojson
@@ -30,12 +30,11 @@
     "ssuberlin:spatial_alias":"Reinickendorf",
     "ssuberlin:spatial_name":"12",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
-        101909779,
-        102063937
+        101909779
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -46,14 +45,13 @@
             "borough_id":1108815551,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815551,
-    "wof:lastmodified":1558998008,
+    "wof:lastmodified":1563999774,
     "wof:name":"Reinickendorf",
     "wof:parent_id":101909779,
     "wof:placetype":"borough",

--- a/data/110/881/555/3/1108815553.geojson
+++ b/data/110/881/555/3/1108815553.geojson
@@ -30,12 +30,11 @@
     "ssuberlin:spatial_alias":"Spandau",
     "ssuberlin:spatial_name":"05",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
-        101909779,
-        102063937
+        101909779
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -46,14 +45,13 @@
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815553,
-    "wof:lastmodified":1558998009,
+    "wof:lastmodified":1563999775,
     "wof:name":"Spandau",
     "wof:parent_id":101909779,
     "wof:placetype":"borough",

--- a/data/110/881/555/5/1108815555.geojson
+++ b/data/110/881/555/5/1108815555.geojson
@@ -30,12 +30,11 @@
     "ssuberlin:spatial_alias":"Steglitz-Zehlendorf",
     "ssuberlin:spatial_name":"06",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
-        101909779,
-        102063937
+        101909779
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -46,14 +45,13 @@
             "borough_id":1108815555,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815555,
-    "wof:lastmodified":1558998009,
+    "wof:lastmodified":1563999775,
     "wof:name":"Steglitz-Zehlendorf",
     "wof:parent_id":101909779,
     "wof:placetype":"borough",

--- a/data/110/881/555/7/1108815557.geojson
+++ b/data/110/881/555/7/1108815557.geojson
@@ -30,12 +30,11 @@
     "ssuberlin:spatial_alias":"Tempelhof-Sch\u00f6neberg",
     "ssuberlin:spatial_name":"07",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
-        101909779,
-        102063937
+        101909779
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -46,14 +45,13 @@
             "borough_id":1108815557,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815557,
-    "wof:lastmodified":1558998009,
+    "wof:lastmodified":1563999775,
     "wof:name":"Tempelhof-Schoneberg",
     "wof:parent_id":101909779,
     "wof:placetype":"borough",

--- a/data/110/881/555/9/1108815559.geojson
+++ b/data/110/881/555/9/1108815559.geojson
@@ -30,12 +30,11 @@
     "ssuberlin:spatial_alias":"Treptow-K\u00f6penick",
     "ssuberlin:spatial_name":"09",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
-        101909779,
-        102063937
+        101909779
     ],
     "wof:breaches":[],
     "wof:concordances":{},
@@ -46,14 +45,13 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":1108815559,
-    "wof:lastmodified":1558998009,
+    "wof:lastmodified":1563999775,
     "wof:name":"Treptow-Kopenick",
     "wof:parent_id":101909779,
     "wof:placetype":"borough",

--- a/data/420/784/223/420784223.geojson
+++ b/data/420/784/223/420784223.geojson
@@ -80,13 +80,12 @@
     "ssuberlin:spatial_name":"0502",
     "wd:wordcount":129,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815553,
-        102063937,
-        85682553
+        1108815553
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -103,15 +102,14 @@
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784223,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784223,
-    "wof:lastmodified":1563276090,
+    "wof:lastmodified":1563999777,
     "wof:name":"Haselhorst",
     "wof:parent_id":1108815553,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/225/420784225.geojson
+++ b/data/420/784/225/420784225.geojson
@@ -95,13 +95,12 @@
     "ssuberlin:spatial_name":"0503",
     "wd:wordcount":196,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815553,
-        102063937,
-        85682553
+        1108815553
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -118,15 +117,14 @@
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784225,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784225,
-    "wof:lastmodified":1563276093,
+    "wof:lastmodified":1563999777,
     "wof:name":"Siemensstadt",
     "wof:parent_id":1108815553,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/229/420784229.geojson
+++ b/data/420/784/229/420784229.geojson
@@ -83,13 +83,12 @@
     "ssuberlin:spatial_name":"1205",
     "wd:wordcount":395,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815551,
-        102063937,
-        85682553
+        1108815551
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -105,15 +104,14 @@
             "borough_id":1108815551,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784229,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784229,
-    "wof:lastmodified":1563276071,
+    "wof:lastmodified":1563999778,
     "wof:name":"Frohnau",
     "wof:parent_id":1108815551,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/231/420784231.geojson
+++ b/data/420/784/231/420784231.geojson
@@ -94,13 +94,12 @@
     "ssuberlin:spatial_alias":"Hermsdorf",
     "ssuberlin:spatial_name":"1206",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815551,
-        102063937
+        1108815551
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -116,15 +115,14 @@
             "borough_id":1108815551,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784231,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784231,
-    "wof:lastmodified":1558998771,
+    "wof:lastmodified":1563999778,
     "wof:name":"Hermsdorf",
     "wof:parent_id":1108815551,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/233/420784233.geojson
+++ b/data/420/784/233/420784233.geojson
@@ -77,13 +77,12 @@
     "ssuberlin:spatial_name":"1209",
     "wd:wordcount":371,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815551,
-        102063937,
-        85682553
+        1108815551
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -100,15 +99,14 @@
             "borough_id":1108815551,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784233,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784233,
-    "wof:lastmodified":1563276079,
+    "wof:lastmodified":1563999778,
     "wof:name":"Wittenau",
     "wof:parent_id":1108815551,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/235/420784235.geojson
+++ b/data/420/784/235/420784235.geojson
@@ -80,13 +80,12 @@
     "ssuberlin:spatial_name":"1207",
     "wd:wordcount":226,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815551,
-        102063937,
-        85682553
+        1108815551
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -103,15 +102,14 @@
             "borough_id":1108815551,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784235,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784235,
-    "wof:lastmodified":1563276076,
+    "wof:lastmodified":1563999798,
     "wof:name":"Waidmannslust",
     "wof:parent_id":1108815551,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/237/420784237.geojson
+++ b/data/420/784/237/420784237.geojson
@@ -77,13 +77,12 @@
     "ssuberlin:spatial_name":"1208",
     "wd:wordcount":314,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815551,
-        102063937,
-        85682553
+        1108815551
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -100,15 +99,14 @@
             "borough_id":1108815551,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784237,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784237,
-    "wof:lastmodified":1563276095,
+    "wof:lastmodified":1563999779,
     "wof:name":"Lubars",
     "wof:parent_id":1108815551,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/241/420784241.geojson
+++ b/data/420/784/241/420784241.geojson
@@ -91,13 +91,12 @@
     "ssuberlin:spatial_alias":"Rosenthal",
     "ssuberlin:spatial_name":"0312",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815549,
-        102063937
+        1108815549
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -112,15 +111,14 @@
             "borough_id":1108815549,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784241,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784241,
-    "wof:lastmodified":1558998773,
+    "wof:lastmodified":1563999779,
     "wof:name":"Rosenthal",
     "wof:parent_id":1108815549,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/243/420784243.geojson
+++ b/data/420/784/243/420784243.geojson
@@ -149,13 +149,12 @@
     "ssuberlin:spatial_name":"1201",
     "wd:wordcount":153,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815551,
-        102063937,
-        85682553
+        1108815551
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -172,15 +171,14 @@
             "borough_id":1108815551,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784243,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784243,
-    "wof:lastmodified":1563276074,
+    "wof:lastmodified":1563999777,
     "wof:name":"Reinickendorf",
     "wof:parent_id":1108815551,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/247/420784247.geojson
+++ b/data/420/784/247/420784247.geojson
@@ -89,13 +89,12 @@
     "ssuberlin:spatial_name":"0311",
     "wd:wordcount":498,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815549,
-        102063937,
-        85682553
+        1108815549
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -112,15 +111,14 @@
             "borough_id":1108815549,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784247,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784247,
-    "wof:lastmodified":1563276090,
+    "wof:lastmodified":1563999779,
     "wof:name":"Niederschonhausen",
     "wof:parent_id":1108815549,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/249/420784249.geojson
+++ b/data/420/784/249/420784249.geojson
@@ -40,13 +40,12 @@
     "ssuberlin:spatial_alias":"Malchow",
     "ssuberlin:spatial_name":"1106",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815539,
-        102063937
+        1108815539
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -61,15 +60,14 @@
             "borough_id":1108815539,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784249,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784249,
-    "wof:lastmodified":1558998801,
+    "wof:lastmodified":1563999796,
     "wof:name":"Malchow",
     "wof:parent_id":1108815539,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/251/420784251.geojson
+++ b/data/420/784/251/420784251.geojson
@@ -86,13 +86,12 @@
     "ssuberlin:spatial_name":"0310",
     "wd:wordcount":288,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815549,
-        102063937,
-        85682553
+        1108815549
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -109,15 +108,14 @@
             "borough_id":1108815549,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784251,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784251,
-    "wof:lastmodified":1563276078,
+    "wof:lastmodified":1563999779,
     "wof:name":"Franzosisch Buchholz",
     "wof:parent_id":1108815549,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/253/420784253.geojson
+++ b/data/420/784/253/420784253.geojson
@@ -65,13 +65,12 @@
     "ssuberlin:spatial_name":"0305",
     "wd:wordcount":27,
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815549,
-        102063937
+        1108815549
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -87,15 +86,14 @@
             "borough_id":1108815549,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784253,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784253,
-    "wof:lastmodified":1558998774,
+    "wof:lastmodified":1563999779,
     "wof:name":"Karow",
     "wof:parent_id":1108815549,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/255/420784255.geojson
+++ b/data/420/784/255/420784255.geojson
@@ -43,13 +43,12 @@
     "ssuberlin:spatial_alias":"Buch",
     "ssuberlin:spatial_name":"0309",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815549,
-        102063937
+        1108815549
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -65,15 +64,14 @@
             "borough_id":1108815549,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784255,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784255,
-    "wof:lastmodified":1558998775,
+    "wof:lastmodified":1563999780,
     "wof:name":"Buch",
     "wof:parent_id":1108815549,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/257/420784257.geojson
+++ b/data/420/784/257/420784257.geojson
@@ -43,13 +43,12 @@
     "ssuberlin:spatial_alias":"Blankenburg",
     "ssuberlin:spatial_name":"0303",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815549,
-        102063937
+        1108815549
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -65,15 +64,14 @@
             "borough_id":1108815549,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784257,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784257,
-    "wof:lastmodified":1559008453,
+    "wof:lastmodified":1563999798,
     "wof:name":"Blankenberg",
     "wof:parent_id":1108815549,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/259/420784259.geojson
+++ b/data/420/784/259/420784259.geojson
@@ -158,13 +158,12 @@
     "ssuberlin:spatial_name":"0307",
     "wd:wordcount":378,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815549,
-        102063937,
-        85682553
+        1108815549
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -181,15 +180,14 @@
             "borough_id":1108815549,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784259,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784259,
-    "wof:lastmodified":1563276075,
+    "wof:lastmodified":1563999781,
     "wof:name":"Pankow",
     "wof:parent_id":1108815549,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/261/420784261.geojson
+++ b/data/420/784/261/420784261.geojson
@@ -86,13 +86,12 @@
     "ssuberlin:spatial_name":"0304",
     "wd:wordcount":256,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815549,
-        102063937,
-        85682553
+        1108815549
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -109,15 +108,14 @@
             "borough_id":1108815549,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784261,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784261,
-    "wof:lastmodified":1563276075,
+    "wof:lastmodified":1563999781,
     "wof:name":"Heinersdorf",
     "wof:parent_id":1108815549,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/265/420784265.geojson
+++ b/data/420/784/265/420784265.geojson
@@ -77,13 +77,12 @@
     "ssuberlin:spatial_name":"1107",
     "wd:wordcount":224,
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815539,
-        102063937
+        1108815539
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -99,15 +98,14 @@
             "borough_id":1108815539,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784265,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784265,
-    "wof:lastmodified":1558998787,
+    "wof:lastmodified":1563999796,
     "wof:name":"Wartenberg",
     "wof:parent_id":1108815539,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/267/420784267.geojson
+++ b/data/420/784/267/420784267.geojson
@@ -92,13 +92,12 @@
     "ssuberlin:spatial_name":"1005",
     "wd:wordcount":229,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815541,
-        102063937,
-        85682553
+        1108815541
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -115,15 +114,14 @@
             "borough_id":1108815541,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784267,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784267,
-    "wof:lastmodified":1563276076,
+    "wof:lastmodified":1563999781,
     "wof:name":"Hellersdorf",
     "wof:parent_id":1108815541,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/269/420784269.geojson
+++ b/data/420/784/269/420784269.geojson
@@ -104,13 +104,12 @@
     "ssuberlin:spatial_name":"1002",
     "wd:wordcount":37,
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815541,
-        102063937
+        1108815541
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -126,15 +125,14 @@
             "borough_id":1108815541,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784269,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784269,
-    "wof:lastmodified":1558998778,
+    "wof:lastmodified":1563999781,
     "wof:name":"Biesdorf",
     "wof:parent_id":1108815541,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/273/420784273.geojson
+++ b/data/420/784/273/420784273.geojson
@@ -260,13 +260,12 @@
     "ssuberlin:spatial_name":"1001",
     "wd:wordcount":544,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815541,
-        102063937,
-        85682553
+        1108815541
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -283,15 +282,14 @@
             "borough_id":1108815541,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784273,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784273,
-    "wof:lastmodified":1563276071,
+    "wof:lastmodified":1563999781,
     "wof:name":"Marzahn",
     "wof:parent_id":1108815541,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/275/420784275.geojson
+++ b/data/420/784/275/420784275.geojson
@@ -88,13 +88,12 @@
     "ssuberlin:spatial_alias":"Wei\u00dfensee",
     "ssuberlin:spatial_name":"0302",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815549,
-        102063937
+        1108815549
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -110,15 +109,14 @@
             "borough_id":1108815549,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784275,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784275,
-    "wof:lastmodified":1558998779,
+    "wof:lastmodified":1563999782,
     "wof:name":"Weissensee",
     "wof:parent_id":1108815549,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/277/420784277.geojson
+++ b/data/420/784/277/420784277.geojson
@@ -37,13 +37,12 @@
     "ssuberlin:spatial_alias":"Lichtenberg",
     "ssuberlin:spatial_name":"1103",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815539,
-        102063937
+        1108815539
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -59,15 +58,14 @@
             "borough_id":1108815539,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784277,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784277,
-    "wof:lastmodified":1558998780,
+    "wof:lastmodified":1563999782,
     "wof:name":"Lichtenberg",
     "wof:parent_id":1108815539,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/279/420784279.geojson
+++ b/data/420/784/279/420784279.geojson
@@ -89,13 +89,12 @@
     "ssuberlin:spatial_name":"1101",
     "wd:wordcount":217,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815539,
-        102063937,
-        85682553
+        1108815539
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -112,15 +111,14 @@
             "borough_id":1108815539,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784279,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784279,
-    "wof:lastmodified":1563276089,
+    "wof:lastmodified":1563999782,
     "wof:name":"Friedrichsfelde",
     "wof:parent_id":1108815539,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/283/420784283.geojson
+++ b/data/420/784/283/420784283.geojson
@@ -64,13 +64,12 @@
     "ssuberlin:spatial_alias":"Prenzlauer Berg",
     "ssuberlin:spatial_name":"0301",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815549,
-        102063937
+        1108815549
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -86,15 +85,14 @@
             "borough_id":1108815549,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784283,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784283,
-    "wof:lastmodified":1558998781,
+    "wof:lastmodified":1563999782,
     "wof:name":"Prenzlauer Berg",
     "wof:parent_id":1108815549,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/285/420784285.geojson
+++ b/data/420/784/285/420784285.geojson
@@ -409,13 +409,12 @@
     "ssuberlin:spatial_name":"0105",
     "wd:wordcount":5274,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815545,
-        102063937,
-        85682553
+        1108815545
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -432,15 +431,14 @@
             "borough_id":1108815545,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784285,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784285,
-    "wof:lastmodified":1563276092,
+    "wof:lastmodified":1563999783,
     "wof:name":"Wedding",
     "wof:parent_id":1108815545,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/287/420784287.geojson
+++ b/data/420/784/287/420784287.geojson
@@ -170,13 +170,12 @@
     "ssuberlin:spatial_name":"0401",
     "wd:wordcount":1943,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815535,
-        102063937,
-        85682553
+        1108815535
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -192,15 +191,14 @@
             "borough_id":1108815535,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784287,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784287,
-    "wof:lastmodified":1563276072,
+    "wof:lastmodified":1563999783,
     "wof:name":"Charlottenburg",
     "wof:parent_id":1108815535,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/289/420784289.geojson
+++ b/data/420/784/289/420784289.geojson
@@ -92,13 +92,12 @@
     "ssuberlin:spatial_name":"0406",
     "wd:wordcount":457,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815535,
-        102063937,
-        85682553
+        1108815535
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -115,15 +114,14 @@
             "borough_id":1108815535,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784289,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784289,
-    "wof:lastmodified":1563276073,
+    "wof:lastmodified":1563999783,
     "wof:name":"Charlottenburg-Nord",
     "wof:parent_id":1108815535,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/291/420784291.geojson
+++ b/data/420/784/291/420784291.geojson
@@ -43,13 +43,12 @@
     "ssuberlin:spatial_alias":"Falkenberg",
     "ssuberlin:spatial_name":"1104",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815539,
-        102063937
+        1108815539
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -65,15 +64,14 @@
             "borough_id":1108815539,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784291,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784291,
-    "wof:lastmodified":1558998802,
+    "wof:lastmodified":1563999796,
     "wof:name":"Falkenberg",
     "wof:parent_id":1108815539,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/293/420784293.geojson
+++ b/data/420/784/293/420784293.geojson
@@ -174,13 +174,12 @@
     "ssuberlin:spatial_name":"0101",
     "wd:wordcount":668,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815545,
-        102063937,
-        85682553
+        1108815545
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -197,15 +196,14 @@
             "borough_id":1108815545,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784293,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784293,
-    "wof:lastmodified":1563276077,
+    "wof:lastmodified":1563999783,
     "wof:name":"Mitte",
     "wof:parent_id":1108815545,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/305/420784305.geojson
+++ b/data/420/784/305/420784305.geojson
@@ -125,13 +125,12 @@
     "ssuberlin:spatial_name":"0202",
     "wd:wordcount":1932,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815537,
-        102063937,
-        85682553
+        1108815537
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -148,15 +147,14 @@
             "borough_id":1108815537,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784305,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784305,
-    "wof:lastmodified":1563276088,
+    "wof:lastmodified":1563999784,
     "wof:name":"Kreuzberg",
     "wof:parent_id":1108815537,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/307/420784307.geojson
+++ b/data/420/784/307/420784307.geojson
@@ -89,13 +89,12 @@
     "ssuberlin:spatial_name":"0104",
     "wd:wordcount":60,
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815545,
-        102063937
+        1108815545
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,15 +110,14 @@
             "borough_id":1108815545,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784307,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784307,
-    "wof:lastmodified":1558998880,
+    "wof:lastmodified":1563999791,
     "wof:name":"Tiergarten",
     "wof:parent_id":1108815545,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/309/420784309.geojson
+++ b/data/420/784/309/420784309.geojson
@@ -167,13 +167,12 @@
     "ssuberlin:spatial_name":"0501",
     "wd:wordcount":409,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815553,
-        102063937,
-        85682553
+        1108815553
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -190,15 +189,14 @@
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784309,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784309,
-    "wof:lastmodified":1563276068,
+    "wof:lastmodified":1563999784,
     "wof:name":"Spandau",
     "wof:parent_id":1108815553,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/311/420784311.geojson
+++ b/data/420/784/311/420784311.geojson
@@ -74,13 +74,12 @@
     "ssuberlin:spatial_name":"0507",
     "wd:wordcount":294,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815553,
-        102063937,
-        85682553
+        1108815553
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -97,15 +96,14 @@
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784311,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784311,
-    "wof:lastmodified":1563276096,
+    "wof:lastmodified":1563999784,
     "wof:name":"Hakenfelde",
     "wof:parent_id":1108815553,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/313/420784313.geojson
+++ b/data/420/784/313/420784313.geojson
@@ -68,13 +68,12 @@
     "ssuberlin:spatial_name":"1203",
     "wd:wordcount":331,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815551,
-        102063937,
-        85682553
+        1108815551
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -91,15 +90,14 @@
             "borough_id":1108815551,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784313,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784313,
-    "wof:lastmodified":1563276084,
+    "wof:lastmodified":1563999796,
     "wof:name":"Konradshohe",
     "wof:parent_id":1108815551,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/315/420784315.geojson
+++ b/data/420/784/315/420784315.geojson
@@ -77,13 +77,12 @@
     "ssuberlin:spatial_name":"0508",
     "wd:wordcount":217,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815553,
-        102063937,
-        85682553
+        1108815553
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -100,15 +99,14 @@
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784315,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784315,
-    "wof:lastmodified":1563276082,
+    "wof:lastmodified":1563999784,
     "wof:name":"Falkenhagener Feld",
     "wof:parent_id":1108815553,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/321/420784321.geojson
+++ b/data/420/784/321/420784321.geojson
@@ -266,13 +266,12 @@
     "ssuberlin:spatial_name":"0404",
     "wd:wordcount":511,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815535,
-        102063937,
-        85682553
+        1108815535
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -288,15 +287,14 @@
             "borough_id":1108815535,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784321,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784321,
-    "wof:lastmodified":1563276098,
+    "wof:lastmodified":1563999785,
     "wof:name":"Grunewald",
     "wof:parent_id":1108815535,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/323/420784323.geojson
+++ b/data/420/784/323/420784323.geojson
@@ -92,13 +92,12 @@
     "ssuberlin:spatial_name":"0403",
     "wd:wordcount":440,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815535,
-        102063937,
-        85682553
+        1108815535
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -115,15 +114,14 @@
             "borough_id":1108815535,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784323,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784323,
-    "wof:lastmodified":1563276081,
+    "wof:lastmodified":1563999785,
     "wof:name":"Schmargendorf",
     "wof:parent_id":1108815535,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/325/420784325.geojson
+++ b/data/420/784/325/420784325.geojson
@@ -110,13 +110,12 @@
     "ssuberlin:spatial_name":"0402",
     "wd:wordcount":510,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815535,
-        102063937,
-        85682553
+        1108815535
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -133,15 +132,14 @@
             "borough_id":1108815535,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784325,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784325,
-    "wof:lastmodified":1563276084,
+    "wof:lastmodified":1563999785,
     "wof:name":"Wilmersdorf",
     "wof:parent_id":1108815535,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/327/420784327.geojson
+++ b/data/420/784/327/420784327.geojson
@@ -67,13 +67,12 @@
     "ssuberlin:spatial_alias":"Sch\u00f6neberg",
     "ssuberlin:spatial_name":"0701",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815557,
-        102063937
+        1108815557
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -89,15 +88,14 @@
             "borough_id":1108815557,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784327,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784327,
-    "wof:lastmodified":1558998790,
+    "wof:lastmodified":1563999785,
     "wof:name":"Schoneberg",
     "wof:parent_id":1108815557,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/329/420784329.geojson
+++ b/data/420/784/329/420784329.geojson
@@ -102,13 +102,12 @@
     "ssuberlin:spatial_name":"0702",
     "wd:wordcount":916,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815557,
-        102063937,
-        85682553
+        1108815557
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -125,15 +124,14 @@
             "borough_id":1108815557,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784329,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784329,
-    "wof:lastmodified":1563276096,
+    "wof:lastmodified":1563999797,
     "wof:name":"Friedenau",
     "wof:parent_id":1108815557,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/331/420784331.geojson
+++ b/data/420/784/331/420784331.geojson
@@ -125,13 +125,12 @@
     "ssuberlin:spatial_name":"0703",
     "wd:wordcount":500,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815557,
-        102063937,
-        85682553
+        1108815557
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -148,15 +147,14 @@
             "borough_id":1108815557,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784331,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784331,
-    "wof:lastmodified":1563276069,
+    "wof:lastmodified":1563999786,
     "wof:name":"Tempelhof",
     "wof:parent_id":1108815557,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/333/420784333.geojson
+++ b/data/420/784/333/420784333.geojson
@@ -119,13 +119,12 @@
     "ssuberlin:spatial_name":"0601",
     "wd:wordcount":821,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815555,
-        102063937,
-        85682553
+        1108815555
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -142,15 +141,14 @@
             "borough_id":1108815555,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784333,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784333,
-    "wof:lastmodified":1563276087,
+    "wof:lastmodified":1563999786,
     "wof:name":"Steglitz",
     "wof:parent_id":1108815555,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/337/420784337.geojson
+++ b/data/420/784/337/420784337.geojson
@@ -56,13 +56,12 @@
     "ssuberlin:spatial_name":"0602",
     "wd:wordcount":36,
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815555,
-        102063937
+        1108815555
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -78,15 +77,14 @@
             "borough_id":1108815555,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784337,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784337,
-    "wof:lastmodified":1558998789,
+    "wof:lastmodified":1563999785,
     "wof:name":"Lichterfelde",
     "wof:parent_id":1108815555,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/339/420784339.geojson
+++ b/data/420/784/339/420784339.geojson
@@ -77,13 +77,12 @@
     "ssuberlin:spatial_name":"0603",
     "wd:wordcount":264,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815555,
-        102063937,
-        85682553
+        1108815555
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -100,15 +99,14 @@
             "borough_id":1108815555,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784339,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784339,
-    "wof:lastmodified":1563276069,
+    "wof:lastmodified":1563999786,
     "wof:name":"Lankwitz",
     "wof:parent_id":1108815555,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/341/420784341.geojson
+++ b/data/420/784/341/420784341.geojson
@@ -89,13 +89,12 @@
     "ssuberlin:spatial_name":"0606",
     "wd:wordcount":388,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815555,
-        102063937,
-        85682553
+        1108815555
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,15 +110,14 @@
             "borough_id":1108815555,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784341,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784341,
-    "wof:lastmodified":1563276080,
+    "wof:lastmodified":1563999787,
     "wof:name":"Nikolassee",
     "wof:parent_id":1108815555,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/343/420784343.geojson
+++ b/data/420/784/343/420784343.geojson
@@ -68,13 +68,12 @@
     "ssuberlin:spatial_name":"0604",
     "wd:wordcount":22,
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815555,
-        102063937
+        1108815555
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -90,15 +89,14 @@
             "borough_id":1108815555,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784343,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784343,
-    "wof:lastmodified":1558998792,
+    "wof:lastmodified":1563999787,
     "wof:name":"Zehlendorf",
     "wof:parent_id":1108815555,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/345/420784345.geojson
+++ b/data/420/784/345/420784345.geojson
@@ -111,13 +111,12 @@
     "ssuberlin:spatial_name":"0607",
     "wd:wordcount":707,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815555,
-        102063937,
-        85682553
+        1108815555
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -134,15 +133,14 @@
             "borough_id":1108815555,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784345,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784345,
-    "wof:lastmodified":1563276097,
+    "wof:lastmodified":1563999792,
     "wof:name":"Wannsee",
     "wof:parent_id":1108815555,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/347/420784347.geojson
+++ b/data/420/784/347/420784347.geojson
@@ -95,13 +95,12 @@
     "ssuberlin:spatial_name":"0505",
     "wd:wordcount":445,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815553,
-        102063937,
-        85682553
+        1108815553
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -117,15 +116,14 @@
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784347,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784347,
-    "wof:lastmodified":1563276083,
+    "wof:lastmodified":1563999797,
     "wof:name":"Gatow",
     "wof:parent_id":1108815553,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/349/420784349.geojson
+++ b/data/420/784/349/420784349.geojson
@@ -89,13 +89,12 @@
     "ssuberlin:spatial_name":"0705",
     "wd:wordcount":335,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815557,
-        102063937,
-        85682553
+        1108815557
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -112,15 +111,14 @@
             "borough_id":1108815557,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784349,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784349,
-    "wof:lastmodified":1563276083,
+    "wof:lastmodified":1563999787,
     "wof:name":"Marienfelde",
     "wof:parent_id":1108815557,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/351/420784351.geojson
+++ b/data/420/784/351/420784351.geojson
@@ -89,13 +89,12 @@
     "ssuberlin:spatial_name":"0704",
     "wd:wordcount":317,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815557,
-        102063937,
-        85682553
+        1108815557
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -112,15 +111,14 @@
             "borough_id":1108815557,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784351,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784351,
-    "wof:lastmodified":1563276086,
+    "wof:lastmodified":1563999787,
     "wof:name":"Mariendorf",
     "wof:parent_id":1108815557,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/355/420784355.geojson
+++ b/data/420/784/355/420784355.geojson
@@ -95,13 +95,12 @@
     "ssuberlin:spatial_name":"0706",
     "wd:wordcount":286,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815557,
-        102063937,
-        85682553
+        1108815557
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -118,15 +117,14 @@
             "borough_id":1108815557,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784355,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784355,
-    "wof:lastmodified":1563276070,
+    "wof:lastmodified":1563999788,
     "wof:name":"Lichtenrade",
     "wof:parent_id":1108815557,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/357/420784357.geojson
+++ b/data/420/784/357/420784357.geojson
@@ -73,13 +73,12 @@
     "ssuberlin:spatial_alias":"Britz",
     "ssuberlin:spatial_name":"0802",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815547,
-        102063937
+        1108815547
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -95,15 +94,14 @@
             "borough_id":1108815547,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784357,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784357,
-    "wof:lastmodified":1558998794,
+    "wof:lastmodified":1563999788,
     "wof:name":"Britz",
     "wof:parent_id":1108815547,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/359/420784359.geojson
+++ b/data/420/784/359/420784359.geojson
@@ -86,13 +86,12 @@
     "ssuberlin:spatial_name":"0804",
     "wd:wordcount":276,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815547,
-        102063937,
-        85682553
+        1108815547
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -108,15 +107,14 @@
             "borough_id":1108815547,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784359,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784359,
-    "wof:lastmodified":1563276085,
+    "wof:lastmodified":1563999791,
     "wof:name":"Rudow",
     "wof:parent_id":1108815547,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/361/420784361.geojson
+++ b/data/420/784/361/420784361.geojson
@@ -89,13 +89,12 @@
     "ssuberlin:spatial_name":"0903",
     "wd:wordcount":317,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815559,
-        102063937,
-        85682553
+        1108815559
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -112,15 +111,14 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784361,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784361,
-    "wof:lastmodified":1563276085,
+    "wof:lastmodified":1563999788,
     "wof:name":"Baumschulenweg",
     "wof:parent_id":1108815559,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/363/420784363.geojson
+++ b/data/420/784/363/420784363.geojson
@@ -140,13 +140,12 @@
     "ssuberlin:spatial_name":"0801",
     "wd:wordcount":586,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815547,
-        102063937,
-        85682553
+        1108815547
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -163,15 +162,14 @@
             "borough_id":1108815547,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784363,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784363,
-    "wof:lastmodified":1563276070,
+    "wof:lastmodified":1563999788,
     "wof:name":"Neukolln",
     "wof:parent_id":1108815547,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/365/420784365.geojson
+++ b/data/420/784/365/420784365.geojson
@@ -50,13 +50,12 @@
     "ssuberlin:spatial_name":"0904",
     "wd:wordcount":52,
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815559,
-        102063937
+        1108815559
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -72,15 +71,14 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784365,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784365,
-    "wof:lastmodified":1558998796,
+    "wof:lastmodified":1563999788,
     "wof:name":"Johannisthal",
     "wof:parent_id":1108815559,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/367/420784367.geojson
+++ b/data/420/784/367/420784367.geojson
@@ -86,13 +86,12 @@
     "ssuberlin:spatial_name":"0906",
     "wd:wordcount":156,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815559,
-        102063937,
-        85682553
+        1108815559
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -109,15 +108,14 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784367,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784367,
-    "wof:lastmodified":1563276087,
+    "wof:lastmodified":1563999789,
     "wof:name":"Altglienicke",
     "wof:parent_id":1108815559,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/369/420784369.geojson
+++ b/data/420/784/369/420784369.geojson
@@ -86,13 +86,12 @@
     "ssuberlin:spatial_name":"0908",
     "wd:wordcount":104,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815559,
-        102063937,
-        85682553
+        1108815559
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -109,15 +108,14 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784369,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784369,
-    "wof:lastmodified":1563276086,
+    "wof:lastmodified":1563999797,
     "wof:name":"Bohnsdorf",
     "wof:parent_id":1108815559,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/373/420784373.geojson
+++ b/data/420/784/373/420784373.geojson
@@ -95,13 +95,12 @@
     "ssuberlin:spatial_name":"0907",
     "wd:wordcount":1180,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815559,
-        102063937,
-        85682553
+        1108815559
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -118,15 +117,14 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784373,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784373,
-    "wof:lastmodified":1563276097,
+    "wof:lastmodified":1563999789,
     "wof:name":"Adlershof",
     "wof:parent_id":1108815559,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/375/420784375.geojson
+++ b/data/420/784/375/420784375.geojson
@@ -37,13 +37,12 @@
     "ssuberlin:spatial_name":"0913",
     "wd:wordcount":133,
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815559,
-        102063937
+        1108815559
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,15 +56,14 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784375,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784375,
-    "wof:lastmodified":1558998796,
+    "wof:lastmodified":1563999789,
     "wof:name":"Grunau",
     "wof:parent_id":1108815559,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/377/420784377.geojson
+++ b/data/420/784/377/420784377.geojson
@@ -275,13 +275,12 @@
     "ssuberlin:spatial_name":"0910",
     "wd:wordcount":1157,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815559,
-        102063937,
-        85682553
+        1108815559
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -298,15 +297,14 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784377,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784377,
-    "wof:lastmodified":1563276081,
+    "wof:lastmodified":1563999789,
     "wof:name":"Kopenick",
     "wof:parent_id":1108815559,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/379/420784379.geojson
+++ b/data/420/784/379/420784379.geojson
@@ -83,13 +83,12 @@
     "ssuberlin:spatial_name":"0914",
     "wd:wordcount":280,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815559,
-        102063937,
-        85682553
+        1108815559
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -106,15 +105,14 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784379,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784379,
-    "wof:lastmodified":1563276079,
+    "wof:lastmodified":1563999791,
     "wof:name":"Muggelheim",
     "wof:parent_id":1108815559,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/381/420784381.geojson
+++ b/data/420/784/381/420784381.geojson
@@ -89,13 +89,12 @@
     "ssuberlin:spatial_name":"0911",
     "wd:wordcount":339,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815559,
-        102063937,
-        85682553
+        1108815559
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -112,15 +111,14 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784381,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784381,
-    "wof:lastmodified":1563276099,
+    "wof:lastmodified":1563999790,
     "wof:name":"Friedrichshagen",
     "wof:parent_id":1108815559,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/383/420784383.geojson
+++ b/data/420/784/383/420784383.geojson
@@ -80,13 +80,12 @@
     "ssuberlin:spatial_name":"0912",
     "wd:wordcount":439,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815559,
-        102063937,
-        85682553
+        1108815559
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -103,15 +102,14 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784383,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784383,
-    "wof:lastmodified":1563276080,
+    "wof:lastmodified":1563999790,
     "wof:name":"Rahnsdorf",
     "wof:parent_id":1108815559,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/385/420784385.geojson
+++ b/data/420/784/385/420784385.geojson
@@ -86,13 +86,12 @@
     "ssuberlin:spatial_name":"0905",
     "wd:wordcount":307,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815559,
-        102063937,
-        85682553
+        1108815559
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -109,15 +108,14 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784385,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784385,
-    "wof:lastmodified":1563276082,
+    "wof:lastmodified":1563999790,
     "wof:name":"Niederschoneweide",
     "wof:parent_id":1108815559,
     "wof:placetype":"neighbourhood",

--- a/data/420/784/387/420784387.geojson
+++ b/data/420/784/387/420784387.geojson
@@ -86,13 +86,12 @@
     "ssuberlin:spatial_name":"0909",
     "wd:wordcount":417,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815559,
-        102063937,
-        85682553
+        1108815559
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -109,15 +108,14 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":420784387,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":420784387,
-    "wof:lastmodified":1563276098,
+    "wof:lastmodified":1563999790,
     "wof:name":"Oberschoneweide",
     "wof:parent_id":1108815559,
     "wof:placetype":"neighbourhood",

--- a/data/858/989/65/85898965.geojson
+++ b/data/858/989/65/85898965.geojson
@@ -60,13 +60,12 @@
     ],
     "src:lbl:centroid":"mz",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815553,
-        102063937
+        1108815553
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -83,18 +82,17 @@
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85898965,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85898965,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1558998807,
+    "wof:lastmodified":1563999790,
     "wof:name":"Amalienhof",
     "wof:parent_id":1108815553,
     "wof:placetype":"neighbourhood",

--- a/data/858/991/71/85899171.geojson
+++ b/data/858/991/71/85899171.geojson
@@ -111,13 +111,12 @@
     "ssuberlin:spatial_alias":"Friedrichshain",
     "ssuberlin:spatial_name":"0201",
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815537,
-        102063937,
-        85682553
+        1108815537
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -134,18 +133,17 @@
             "borough_id":1108815537,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85899171,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85899171,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252430,
+    "wof:lastmodified":1563999794,
     "wof:name":"Friedrichshain",
     "wof:parent_id":1108815537,
     "wof:placetype":"neighbourhood",

--- a/data/858/991/93/85899193.geojson
+++ b/data/858/991/93/85899193.geojson
@@ -118,13 +118,12 @@
     "ssuberlin:spatial_name":"0106",
     "wd:wordcount":562,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815545,
-        102063937,
-        85682553
+        1108815545
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -142,18 +141,17 @@
             "borough_id":1108815545,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85899193,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85899193,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252418,
+    "wof:lastmodified":1563999794,
     "wof:name":"Gesundbrunnen",
     "wof:parent_id":1108815545,
     "wof:placetype":"neighbourhood",

--- a/data/858/992/15/85899215.geojson
+++ b/data/858/992/15/85899215.geojson
@@ -122,13 +122,12 @@
     "ssuberlin:spatial_name":"0805",
     "wd:wordcount":248,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815547,
-        102063937,
-        85682553
+        1108815547
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -146,18 +145,17 @@
             "borough_id":1108815547,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85899215,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85899215,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252504,
+    "wof:lastmodified":1563999793,
     "wof:name":"Gropius-Stadt",
     "wof:parent_id":1108815547,
     "wof:placetype":"neighbourhood",

--- a/data/858/992/39/85899239.geojson
+++ b/data/858/992/39/85899239.geojson
@@ -121,13 +121,12 @@
     "ssuberlin:spatial_name":"0407",
     "wd:wordcount":316,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815535,
-        102063937,
-        85682553
+        1108815535
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -145,18 +144,17 @@
             "borough_id":1108815535,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85899239,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85899239,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252502,
+    "wof:lastmodified":1563999793,
     "wof:name":"Halensee",
     "wof:parent_id":1108815535,
     "wof:placetype":"neighbourhood",

--- a/data/858/992/75/85899275.geojson
+++ b/data/858/992/75/85899275.geojson
@@ -109,13 +109,12 @@
     "ssuberlin:spatial_name":"1204",
     "wd:wordcount":161,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815551,
-        102063937,
-        85682553
+        1108815551
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -132,18 +131,17 @@
             "borough_id":1108815551,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85899275,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85899275,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252499,
+    "wof:lastmodified":1563999797,
     "wof:name":"Heiligensee",
     "wof:parent_id":1108815551,
     "wof:placetype":"neighbourhood",

--- a/data/858/993/31/85899331.geojson
+++ b/data/858/993/31/85899331.geojson
@@ -88,13 +88,12 @@
     ],
     "src:lbl:centroid":"mz",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815553,
-        102063937
+        1108815553
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -110,18 +109,17 @@
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85899331,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85899331,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1559008458,
+    "wof:lastmodified":1563999798,
     "wof:name":"J\u00f6rsfelde",
     "wof:parent_id":1108815553,
     "wof:placetype":"neighbourhood",

--- a/data/858/995/71/85899571.geojson
+++ b/data/858/995/71/85899571.geojson
@@ -96,13 +96,12 @@
     "ssuberlin:spatial_name":"1004",
     "wd:wordcount":264,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815541,
-        102063937,
-        85682553
+        1108815541
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -119,18 +118,17 @@
             "borough_id":1108815541,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85899571,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85899571,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252491,
+    "wof:lastmodified":1563999794,
     "wof:name":"Mahlsdorf",
     "wof:parent_id":1108815541,
     "wof:placetype":"neighbourhood",

--- a/data/858/995/93/85899593.geojson
+++ b/data/858/995/93/85899593.geojson
@@ -117,13 +117,12 @@
     "ssuberlin:spatial_name":"1210",
     "wd:wordcount":168,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815551,
-        102063937,
-        85682553
+        1108815551
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -141,18 +140,17 @@
             "borough_id":1108815551,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85899593,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85899593,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252488,
+    "wof:lastmodified":1563999797,
     "wof:name":"M\u00e4rkisches Viertel",
     "wof:parent_id":1108815551,
     "wof:placetype":"neighbourhood",

--- a/data/858/996/37/85899637.geojson
+++ b/data/858/996/37/85899637.geojson
@@ -142,13 +142,12 @@
     "ssuberlin:spatial_name":"0102",
     "wd:wordcount":1084,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815545,
-        102063937,
-        85682553
+        1108815545
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -166,18 +165,17 @@
             "borough_id":1108815545,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85899637,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85899637,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252437,
+    "wof:lastmodified":1563999794,
     "wof:name":"Moabit",
     "wof:parent_id":1108815545,
     "wof:placetype":"neighbourhood",

--- a/data/858/996/97/85899697.geojson
+++ b/data/858/996/97/85899697.geojson
@@ -89,13 +89,12 @@
     "ssuberlin:spatial_name":"0506",
     "wd:wordcount":440,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815553,
-        102063937,
-        85682553
+        1108815553
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -112,18 +111,17 @@
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85899697,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85899697,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252437,
+    "wof:lastmodified":1563999798,
     "wof:name":"Kladow",
     "wof:parent_id":1108815553,
     "wof:placetype":"neighbourhood",

--- a/data/858/997/11/85899711.geojson
+++ b/data/858/997/11/85899711.geojson
@@ -112,13 +112,12 @@
     "ssuberlin:spatial_name":"0504",
     "wd:wordcount":1261,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815553,
-        102063937,
-        85682553
+        1108815553
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -135,18 +134,17 @@
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85899711,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85899711,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252441,
+    "wof:lastmodified":1563999793,
     "wof:name":"Staaken",
     "wof:parent_id":1108815553,
     "wof:placetype":"neighbourhood",

--- a/data/858/997/57/85899757.geojson
+++ b/data/858/997/57/85899757.geojson
@@ -116,13 +116,12 @@
     "ssuberlin:spatial_name":"1109",
     "wd:wordcount":216,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815539,
-        102063937,
-        85682553
+        1108815539
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -139,18 +138,17 @@
             "borough_id":1108815539,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85899757,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85899757,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252439,
+    "wof:lastmodified":1563999794,
     "wof:name":"Neu-Hohensch\u00f6nhausen",
     "wof:parent_id":1108815539,
     "wof:placetype":"neighbourhood",

--- a/data/858/999/37/85899937.geojson
+++ b/data/858/999/37/85899937.geojson
@@ -64,13 +64,12 @@
     ],
     "src:lbl:centroid":"mz",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815559,
-        102063937
+        1108815559
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -86,18 +85,17 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85899937,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85899937,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1559000263,
+    "wof:lastmodified":1563999797,
     "wof:name":"Rahnsdorferm\u00fchle",
     "wof:parent_id":1108815559,
     "wof:placetype":"neighbourhood",

--- a/data/858/999/81/85899981.geojson
+++ b/data/858/999/81/85899981.geojson
@@ -121,13 +121,12 @@
     "ssuberlin:spatial_name":"1112",
     "wd:wordcount":222,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815539,
-        102063937,
-        85682553
+        1108815539
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -145,18 +144,17 @@
             "borough_id":1108815539,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85899981,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85899981,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252463,
+    "wof:lastmodified":1563999795,
     "wof:name":"Rummelsburg",
     "wof:parent_id":1108815539,
     "wof:placetype":"neighbourhood",

--- a/data/858/999/99/85899999.geojson
+++ b/data/858/999/99/85899999.geojson
@@ -61,13 +61,12 @@
     ],
     "src:lbl:centroid":"mz",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815551,
-        102063937
+        1108815551
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -83,18 +82,17 @@
             "borough_id":1108815551,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85899999,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85899999,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1558998906,
+    "wof:lastmodified":1563999798,
     "wof:name":"Sandhausen",
     "wof:parent_id":1108815551,
     "wof:placetype":"neighbourhood",

--- a/data/859/000/21/85900021.geojson
+++ b/data/859/000/21/85900021.geojson
@@ -61,13 +61,12 @@
     "ssuberlin:spatial_alias":"Schm\u00f6ckwitz",
     "ssuberlin:spatial_name":"0915",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815559,
-        102063937
+        1108815559
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -83,18 +82,17 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85900021,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85900021,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1558998753,
+    "wof:lastmodified":1563999777,
     "wof:name":"Schm\u00f6chwitz",
     "wof:parent_id":1108815559,
     "wof:placetype":"neighbourhood",

--- a/data/859/000/25/85900025.geojson
+++ b/data/859/000/25/85900025.geojson
@@ -110,13 +110,12 @@
     "src:lbl:centroid":"mz",
     "wd:wordcount":353,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815559,
-        102063937,
-        85682553
+        1108815559
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -133,18 +132,17 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85900025,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85900025,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252197,
+    "wof:lastmodified":1563999792,
     "wof:name":"Schm\u00f6ckwitzwerder",
     "wof:parent_id":1108815559,
     "wof:placetype":"neighbourhood",

--- a/data/859/001/25/85900125.geojson
+++ b/data/859/001/25/85900125.geojson
@@ -93,13 +93,12 @@
     "ssuberlin:spatial_name":"1202",
     "wd:wordcount":438,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815551,
-        102063937,
-        85682553
+        1108815551
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -116,18 +115,17 @@
             "borough_id":1108815551,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85900125,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85900125,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252205,
+    "wof:lastmodified":1563999778,
     "wof:name":"Tegel",
     "wof:parent_id":1108815551,
     "wof:placetype":"neighbourhood",

--- a/data/859/002/31/85900231.geojson
+++ b/data/859/002/31/85900231.geojson
@@ -132,13 +132,12 @@
     "ssuberlin:spatial_name":"0405",
     "wd:wordcount":629,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815535,
-        102063937,
-        85682553
+        1108815535
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -156,18 +155,17 @@
             "borough_id":1108815535,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85900231,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85900231,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252218,
+    "wof:lastmodified":1563999786,
     "wof:name":"Westend",
     "wof:parent_id":1108815535,
     "wof:placetype":"neighbourhood",

--- a/data/859/002/41/85900241.geojson
+++ b/data/859/002/41/85900241.geojson
@@ -112,13 +112,12 @@
     "ssuberlin:spatial_name":"0313",
     "wd:wordcount":311,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815549,
-        102063937,
-        85682553
+        1108815549
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -136,18 +135,17 @@
             "borough_id":1108815549,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85900241,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85900241,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252220,
+    "wof:lastmodified":1563999795,
     "wof:name":"Wilhelmsruh",
     "wof:parent_id":1108815549,
     "wof:placetype":"neighbourhood",

--- a/data/859/002/45/85900245.geojson
+++ b/data/859/002/45/85900245.geojson
@@ -108,13 +108,12 @@
     "ssuberlin:spatial_name":"0509",
     "wd:wordcount":329,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815553,
-        102063937,
-        85682553
+        1108815553
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -132,18 +131,17 @@
             "borough_id":1108815553,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85900245,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85900245,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252216,
+    "wof:lastmodified":1563999786,
     "wof:name":"Wilhelmstadt",
     "wof:parent_id":1108815553,
     "wof:placetype":"neighbourhood",

--- a/data/859/056/41/85905641.geojson
+++ b/data/859/056/41/85905641.geojson
@@ -66,13 +66,12 @@
     ],
     "src:lbl:centroid":"mz",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815555,
-        102063937
+        1108815555
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -88,18 +87,17 @@
             "borough_id":1108815555,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85905641,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85905641,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1558998782,
+    "wof:lastmodified":1563999795,
     "wof:name":"Sch\u00f6now",
     "wof:parent_id":1108815555,
     "wof:placetype":"neighbourhood",

--- a/data/859/056/49/85905649.geojson
+++ b/data/859/056/49/85905649.geojson
@@ -226,13 +226,12 @@
     "ssuberlin:spatial_name":"1211",
     "wd:wordcount":249,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815551,
-        102063937,
-        85682553
+        1108815551
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -250,18 +249,17 @@
             "borough_id":1108815551,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85905649,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85905649,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252230,
+    "wof:lastmodified":1563999795,
     "wof:name":"Borsigwalde",
     "wof:parent_id":1108815551,
     "wof:placetype":"neighbourhood",

--- a/data/859/056/59/85905659.geojson
+++ b/data/859/056/59/85905659.geojson
@@ -81,13 +81,12 @@
     "ssuberlin:spatial_name":"1003",
     "wd:wordcount":30,
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815541,
-        102063937
+        1108815541
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -101,18 +100,17 @@
             "borough_id":1108815541,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85905659,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85905659,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1558999241,
+    "wof:lastmodified":1563999792,
     "wof:name":"Kaulsdorf",
     "wof:parent_id":1108815541,
     "wof:placetype":"neighbourhood",

--- a/data/859/076/99/85907699.geojson
+++ b/data/859/076/99/85907699.geojson
@@ -60,13 +60,12 @@
     ],
     "src:lbl:centroid":"mz",
     "wof:belongsto":[
-        85682553,
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815551,
-        102063937
+        1108815551
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -81,18 +80,17 @@
             "borough_id":1108815551,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85907699,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85907699,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1558998751,
+    "wof:lastmodified":1563999797,
     "wof:name":"Krhs",
     "wof:parent_id":1108815551,
     "wof:placetype":"neighbourhood",

--- a/data/859/287/41/85928741.geojson
+++ b/data/859/287/41/85928741.geojson
@@ -126,13 +126,12 @@
     "ssuberlin:spatial_name":"0103",
     "wd:wordcount":231,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815545,
-        102063937,
-        85682553
+        1108815545
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -150,18 +149,17 @@
             "borough_id":1108815545,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85928741,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85928741,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252186,
+    "wof:lastmodified":1563999792,
     "wof:name":"Hansaviertel",
     "wof:parent_id":1108815545,
     "wof:placetype":"neighbourhood",

--- a/data/859/287/43/85928743.geojson
+++ b/data/859/287/43/85928743.geojson
@@ -111,13 +111,12 @@
     "ssuberlin:spatial_name":"0306",
     "wd:wordcount":243,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815549,
-        102063937,
-        85682553
+        1108815549
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -135,18 +134,17 @@
             "borough_id":1108815549,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85928743,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85928743,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252184,
+    "wof:lastmodified":1563999792,
     "wof:name":"Stadtrandsiedlung Malchow",
     "wof:parent_id":1108815549,
     "wof:placetype":"neighbourhood",

--- a/data/859/287/47/85928747.geojson
+++ b/data/859/287/47/85928747.geojson
@@ -114,13 +114,12 @@
     "ssuberlin:spatial_name":"1111",
     "wd:wordcount":322,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815539,
-        102063937,
-        85682553
+        1108815539
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -138,18 +137,17 @@
             "borough_id":1108815539,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85928747,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85928747,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252186,
+    "wof:lastmodified":1563999795,
     "wof:name":"Fennpfuhl",
     "wof:parent_id":1108815539,
     "wof:placetype":"neighbourhood",

--- a/data/859/287/53/85928753.geojson
+++ b/data/859/287/53/85928753.geojson
@@ -120,13 +120,12 @@
     "ssuberlin:spatial_name":"1110",
     "wd:wordcount":1196,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815539,
-        102063937,
-        85682553
+        1108815539
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -144,18 +143,17 @@
             "borough_id":1108815539,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85928753,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85928753,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252185,
+    "wof:lastmodified":1563999793,
     "wof:name":"Alt-Hohensch\u00f6nhausen",
     "wof:parent_id":1108815539,
     "wof:placetype":"neighbourhood",

--- a/data/859/287/89/85928789.geojson
+++ b/data/859/287/89/85928789.geojson
@@ -118,13 +118,12 @@
     "ssuberlin:spatial_name":"0902",
     "wd:wordcount":260,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815559,
-        102063937,
-        85682553
+        1108815559
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -142,18 +141,17 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85928789,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85928789,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252184,
+    "wof:lastmodified":1563999793,
     "wof:name":"Pl\u00e4nterwald",
     "wof:parent_id":1108815559,
     "wof:placetype":"neighbourhood",

--- a/data/859/287/93/85928793.geojson
+++ b/data/859/287/93/85928793.geojson
@@ -124,13 +124,12 @@
     "ssuberlin:spatial_name":"0901",
     "wd:wordcount":248,
     "wof:belongsto":[
+        85682499,
         102191581,
-        1377683779,
+        1377694153,
         85633111,
         101909779,
-        1108815559,
-        102063937,
-        85682553
+        1108815559
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -148,18 +147,17 @@
             "borough_id":1108815559,
             "continent_id":102191581,
             "country_id":85633111,
-            "county_id":102063937,
-            "localadmin_id":1377683779,
+            "localadmin_id":1377694153,
             "locality_id":101909779,
             "neighbourhood_id":85928793,
-            "region_id":85682553
+            "region_id":85682499
         }
     ],
     "wof:id":85928793,
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1563252183,
+    "wof:lastmodified":1563999796,
     "wof:name":"Alt-Treptow",
     "wof:parent_id":1108815559,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes whosonfirst-data/whosonfirst-data#1652
Will replace https://github.com/whosonfirst-data/whosonfirst-data-admin-de/pull/9

- Adds a reversegeo, label, and mps centroid - all needed updates
- PIPs the branch to update Berlin and all descendants