### PR TITLE
New neighbourhood records

### DIFF
--- a/data/144/482/769/1/1444827691.geojson
+++ b/data/144/482/769/1/1444827691.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"a503783846090768e83ab00bbca70621",
-    "wof:hierarchy":[],
+    "wof:geomhash":"3e3116ad47548029eead31354a38be68",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827691,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827691,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337914,
     "wof:name":"Sonnenschein",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.508744868889941,
+    8.50874486888994,
     49.52367376921122,
-    8.508744868889941,
+    8.50874486888994,
     49.52367376921122
 ],
   "geometry": {"coordinates":[8.50874486888994,49.52367376921122],"type":"Point"}

--- a/data/144/482/769/1/1444827691.geojson
+++ b/data/144/482/769/1/1444827691.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827691,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.50874486889,49.5236737692,8.50874486889,49.5236737692",
+    "geom:latitude":49.523674,
+    "geom:longitude":8.508745,
+    "iso:country":"DE",
+    "lbl:latitude":49.523674,
+    "lbl:longitude":8.508745,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Sonnenschein"
+    ],
+    "name:eng_x_preferred":[
+        "Sonnenschein"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"a503783846090768e83ab00bbca70621",
+    "wof:hierarchy":[],
+    "wof:id":1444827691,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Sonnenschein",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.508744868889941,
+    49.52367376921122,
+    8.508744868889941,
+    49.52367376921122
+],
+  "geometry": {"coordinates":[8.50874486888994,49.52367376921122],"type":"Point"}
+}

--- a/data/144/482/769/5/1444827695.geojson
+++ b/data/144/482/769/5/1444827695.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827695,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.51172033425,49.5088140106,8.51172033425,49.5088140106",
+    "geom:latitude":49.508814,
+    "geom:longitude":8.51172,
+    "iso:country":"DE",
+    "lbl:latitude":49.508814,
+    "lbl:longitude":8.51172,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "K\u00e4fertal"
+    ],
+    "name:eng_x_preferred":[
+        "Kaefertal"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"07a7fc97fd8cdc33006b6dcbeef9e11f",
+    "wof:hierarchy":[],
+    "wof:id":1444827695,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Kaefertal",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.511720334254239,
+    49.50881401060822,
+    8.511720334254239,
+    49.50881401060822
+],
+  "geometry": {"coordinates":[8.51172033425424,49.50881401060822],"type":"Point"}
+}

--- a/data/144/482/769/5/1444827695.geojson
+++ b/data/144/482/769/5/1444827695.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"07a7fc97fd8cdc33006b6dcbeef9e11f",
-    "wof:hierarchy":[],
+    "wof:geomhash":"3554bf951885113257706d24f3bb24e7",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827695,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827695,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337915,
     "wof:name":"Kaefertal",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.511720334254239,
+    8.51172033425424,
     49.50881401060822,
-    8.511720334254239,
+    8.51172033425424,
     49.50881401060822
 ],
   "geometry": {"coordinates":[8.51172033425424,49.50881401060822],"type":"Point"}

--- a/data/144/482/770/1/1444827701.geojson
+++ b/data/144/482/770/1/1444827701.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"22ba34af7087186c93f83e53478a91c5",
-    "wof:hierarchy":[],
+    "wof:geomhash":"258ea2440e6e8507429534061abb21c0",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827701,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827701,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337915,
     "wof:name":"Vogelstang",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.542447736189404,
+    8.5424477361894,
     49.51093180206016,
-    8.542447736189404,
+    8.5424477361894,
     49.51093180206016
 ],
   "geometry": {"coordinates":[8.5424477361894,49.51093180206016],"type":"Point"}

--- a/data/144/482/770/1/1444827701.geojson
+++ b/data/144/482/770/1/1444827701.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827701,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.54244773619,49.5109318021,8.54244773619,49.5109318021",
+    "geom:latitude":49.510932,
+    "geom:longitude":8.542448,
+    "iso:country":"DE",
+    "lbl:latitude":49.510932,
+    "lbl:longitude":8.542448,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Vogelstang"
+    ],
+    "name:eng_x_preferred":[
+        "Vogelstang"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"22ba34af7087186c93f83e53478a91c5",
+    "wof:hierarchy":[],
+    "wof:id":1444827701,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Vogelstang",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.542447736189404,
+    49.51093180206016,
+    8.542447736189404,
+    49.51093180206016
+],
+  "geometry": {"coordinates":[8.5424477361894,49.51093180206016],"type":"Point"}
+}

--- a/data/144/482/770/5/1444827705.geojson
+++ b/data/144/482/770/5/1444827705.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"34275b1ba23ce21a9efc66efa10904d0",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f999759e3c62ad8238c56c0e66acc9d7",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827705,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827705,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337918,
     "wof:name":"Wallstadt",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.553434069842197,
+    8.5534340698422,
     49.4978520458085,
-    8.553434069842197,
+    8.5534340698422,
     49.4978520458085
 ],
   "geometry": {"coordinates":[8.5534340698422,49.4978520458085],"type":"Point"}

--- a/data/144/482/770/5/1444827705.geojson
+++ b/data/144/482/770/5/1444827705.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827705,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.55343406984,49.4978520458,8.55343406984,49.4978520458",
+    "geom:latitude":49.497852,
+    "geom:longitude":8.553434,
+    "iso:country":"DE",
+    "lbl:latitude":49.497852,
+    "lbl:longitude":8.553434,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Wallstadt"
+    ],
+    "name:eng_x_preferred":[
+        "Wallstadt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"34275b1ba23ce21a9efc66efa10904d0",
+    "wof:hierarchy":[],
+    "wof:id":1444827705,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Wallstadt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.553434069842197,
+    49.4978520458085,
+    8.553434069842197,
+    49.4978520458085
+],
+  "geometry": {"coordinates":[8.5534340698422,49.4978520458085],"type":"Point"}
+}

--- a/data/144/482/770/9/1444827709.geojson
+++ b/data/144/482/770/9/1444827709.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827709,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.5288292601,49.487408026,8.5288292601,49.487408026",
+    "geom:latitude":49.487408,
+    "geom:longitude":8.528829,
+    "iso:country":"DE",
+    "lbl:latitude":49.487408,
+    "lbl:longitude":8.528829,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Feudenheim"
+    ],
+    "name:eng_x_preferred":[
+        "Feudenheim"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"5aac1d703dea4fb6149977c6dba2dbae",
+    "wof:hierarchy":[],
+    "wof:id":1444827709,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Feudenheim",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.52882926009896,
+    49.48740802596321,
+    8.52882926009896,
+    49.48740802596321
+],
+  "geometry": {"coordinates":[8.52882926009896,49.48740802596321],"type":"Point"}
+}

--- a/data/144/482/770/9/1444827709.geojson
+++ b/data/144/482/770/9/1444827709.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
     "wof:geomhash":"5aac1d703dea4fb6149977c6dba2dbae",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827709,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827709,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337919,
     "wof:name":"Feudenheim",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],

--- a/data/144/482/771/3/1444827713.geojson
+++ b/data/144/482/771/3/1444827713.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827713,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.49255147085,49.4940240695,8.49255147085,49.4940240695",
+    "geom:latitude":49.494024,
+    "geom:longitude":8.492551,
+    "iso:country":"DE",
+    "lbl:latitude":49.494024,
+    "lbl:longitude":8.492551,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Wohlgelegen"
+    ],
+    "name:eng_x_preferred":[
+        "Wohlgelegen"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"1b29fd92064381287f1d5a9a857181f0",
+    "wof:hierarchy":[],
+    "wof:id":1444827713,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Wohlgelegen",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.492551470849627,
+    49.49402406948684,
+    8.492551470849627,
+    49.49402406948684
+],
+  "geometry": {"coordinates":[8.49255147084963,49.49402406948684],"type":"Point"}
+}

--- a/data/144/482/771/3/1444827713.geojson
+++ b/data/144/482/771/3/1444827713.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"1b29fd92064381287f1d5a9a857181f0",
-    "wof:hierarchy":[],
+    "wof:geomhash":"55b35f8ce6ae0acf31906f77e9b139a8",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827713,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827713,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337920,
     "wof:name":"Wohlgelegen",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.492551470849627,
+    8.49255147084963,
     49.49402406948684,
-    8.492551470849627,
+    8.49255147084963,
     49.49402406948684
 ],
   "geometry": {"coordinates":[8.49255147084963,49.49402406948684],"type":"Point"}

--- a/data/144/482/772/1/1444827721.geojson
+++ b/data/144/482/772/1/1444827721.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827721,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.47744526208,49.5064360302,8.47744526208,49.5064360302",
+    "geom:latitude":49.506436,
+    "geom:longitude":8.477445,
+    "iso:country":"DE",
+    "lbl:latitude":49.506436,
+    "lbl:longitude":8.477445,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Herzogenried"
+    ],
+    "name:eng_x_preferred":[
+        "Herzogenried"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"f7190232a8b3a89d216f683ecc193e10",
+    "wof:hierarchy":[],
+    "wof:id":1444827721,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Herzogenried",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.477445262077033,
+    49.506436030238376,
+    8.477445262077033,
+    49.506436030238376
+],
+  "geometry": {"coordinates":[8.47744526207703,49.50643603023838],"type":"Point"}
+}

--- a/data/144/482/772/1/1444827721.geojson
+++ b/data/144/482/772/1/1444827721.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"f7190232a8b3a89d216f683ecc193e10",
-    "wof:hierarchy":[],
+    "wof:geomhash":"72d655b793febd0cc335ca5a163791e5",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827721,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827721,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337920,
     "wof:name":"Herzogenried",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.477445262077033,
-    49.506436030238376,
-    8.477445262077033,
-    49.506436030238376
+    8.47744526207703,
+    49.50643603023838,
+    8.47744526207703,
+    49.50643603023838
 ],
   "geometry": {"coordinates":[8.47744526207703,49.50643603023838],"type":"Point"}
 }

--- a/data/144/482/772/5/1444827725.geojson
+++ b/data/144/482/772/5/1444827725.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827725,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.46062243867,49.4943957308,8.46062243867,49.4943957308",
+    "geom:latitude":49.494396,
+    "geom:longitude":8.460622,
+    "iso:country":"DE",
+    "lbl:latitude":49.494396,
+    "lbl:longitude":8.460622,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Jungbusch"
+    ],
+    "name:eng_x_preferred":[
+        "Jungbusch"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"44c6c4aa5435b94e99a0d8b4c01af705",
+    "wof:hierarchy":[],
+    "wof:id":1444827725,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Jungbusch",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.46062243867119,
+    49.494395730796455,
+    8.46062243867119,
+    49.494395730796455
+],
+  "geometry": {"coordinates":[8.46062243867119,49.49439573079646],"type":"Point"}
+}

--- a/data/144/482/772/5/1444827725.geojson
+++ b/data/144/482/772/5/1444827725.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"44c6c4aa5435b94e99a0d8b4c01af705",
-    "wof:hierarchy":[],
+    "wof:geomhash":"92f9aee34d4a9da9315477b4bd2d0919",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827725,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827725,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337923,
     "wof:name":"Jungbusch",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -46,9 +65,9 @@
 },
   "bbox": [
     8.46062243867119,
-    49.494395730796455,
+    49.49439573079646,
     8.46062243867119,
-    49.494395730796455
+    49.49439573079646
 ],
   "geometry": {"coordinates":[8.46062243867119,49.49439573079646],"type":"Point"}
 }

--- a/data/144/482/773/1/1444827731.geojson
+++ b/data/144/482/773/1/1444827731.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"bd1b44efe83300e71ccbb46ed6b505fa",
-    "wof:hierarchy":[],
+    "wof:geomhash":"65f14f4ccde3b73bcb41a844a51bd963",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827731,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827731,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337924,
     "wof:name":"Innenstadt",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.465428959644289,
+    8.46542895964429,
     49.48696196838347,
-    8.465428959644289,
+    8.46542895964429,
     49.48696196838347
 ],
   "geometry": {"coordinates":[8.46542895964429,49.48696196838347],"type":"Point"}

--- a/data/144/482/773/1/1444827731.geojson
+++ b/data/144/482/773/1/1444827731.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827731,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.46542895964,49.4869619684,8.46542895964,49.4869619684",
+    "geom:latitude":49.486962,
+    "geom:longitude":8.465429,
+    "iso:country":"DE",
+    "lbl:latitude":49.486962,
+    "lbl:longitude":8.465429,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Innenstadt"
+    ],
+    "name:eng_x_preferred":[
+        "Innenstadt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"bd1b44efe83300e71ccbb46ed6b505fa",
+    "wof:hierarchy":[],
+    "wof:id":1444827731,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Innenstadt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.465428959644289,
+    49.48696196838347,
+    8.465428959644289,
+    49.48696196838347
+],
+  "geometry": {"coordinates":[8.46542895964429,49.48696196838347],"type":"Point"}
+}

--- a/data/144/482/773/9/1444827739.geojson
+++ b/data/144/482/773/9/1444827739.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827739,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.44940722307,49.4955106978,8.44940722307,49.4955106978",
+    "geom:latitude":49.495511,
+    "geom:longitude":8.449407,
+    "iso:country":"DE",
+    "lbl:latitude":49.495511,
+    "lbl:longitude":8.449407,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "M\u00fchlau"
+    ],
+    "name:eng_x_preferred":[
+        "Muehlau"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"d42b351120dffabbdc91be0d56856291",
+    "wof:hierarchy":[],
+    "wof:id":1444827739,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Muehlau",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.449407223067295,
+    49.49551069779225,
+    8.449407223067295,
+    49.49551069779225
+],
+  "geometry": {"coordinates":[8.4494072230673,49.49551069779225],"type":"Point"}
+}

--- a/data/144/482/773/9/1444827739.geojson
+++ b/data/144/482/773/9/1444827739.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"d42b351120dffabbdc91be0d56856291",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d1b37066d2080ef58d9bc6cbbce78fb4",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827739,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827739,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337925,
     "wof:name":"Muehlau",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.449407223067295,
+    8.4494072230673,
     49.49551069779225,
-    8.449407223067295,
+    8.4494072230673,
     49.49551069779225
 ],
   "geometry": {"coordinates":[8.4494072230673,49.49551069779225],"type":"Point"}

--- a/data/144/482/774/3/1444827743.geojson
+++ b/data/144/482/774/3/1444827743.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827743,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.46811832257,49.4900099475,8.46811832257,49.4900099475",
+    "geom:latitude":49.49001,
+    "geom:longitude":8.468118,
+    "iso:country":"DE",
+    "lbl:latitude":49.49001,
+    "lbl:longitude":8.468118,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Unterstadt"
+    ],
+    "name:eng_x_preferred":[
+        "Unterstadt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"a959c9c461c18fb7d5115cf3283a5c17",
+    "wof:hierarchy":[],
+    "wof:id":1444827743,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Unterstadt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.468118322569712,
+    49.49000994751254,
+    8.468118322569712,
+    49.49000994751254
+],
+  "geometry": {"coordinates":[8.46811832256971,49.49000994751254],"type":"Point"}
+}

--- a/data/144/482/774/3/1444827743.geojson
+++ b/data/144/482/774/3/1444827743.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"a959c9c461c18fb7d5115cf3283a5c17",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c6f1e87c34f34dc7cd05f18dca618fed",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827743,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827743,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337925,
     "wof:name":"Unterstadt",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.468118322569712,
+    8.46811832256971,
     49.49000994751254,
-    8.468118322569712,
+    8.46811832256971,
     49.49000994751254
 ],
   "geometry": {"coordinates":[8.46811832256971,49.49000994751254],"type":"Point"}

--- a/data/144/482/774/9/1444827749.geojson
+++ b/data/144/482/774/9/1444827749.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"82ea51af6160fcd08788f87603987362",
-    "wof:hierarchy":[],
+    "wof:geomhash":"7d4aca86eb1c3e112ccb98888fa57c54",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827749,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827749,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337928,
     "wof:name":"Oberstadt",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.463998447449914,
+    8.46399844744991,
     49.4854750804324,
-    8.463998447449914,
+    8.46399844744991,
     49.4854750804324
 ],
   "geometry": {"coordinates":[8.46399844744991,49.4854750804324],"type":"Point"}

--- a/data/144/482/774/9/1444827749.geojson
+++ b/data/144/482/774/9/1444827749.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827749,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.46399844745,49.4854750804,8.46399844745,49.4854750804",
+    "geom:latitude":49.485475,
+    "geom:longitude":8.463998,
+    "iso:country":"DE",
+    "lbl:latitude":49.485475,
+    "lbl:longitude":8.463998,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Oberstadt"
+    ],
+    "name:eng_x_preferred":[
+        "Oberstadt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"82ea51af6160fcd08788f87603987362",
+    "wof:hierarchy":[],
+    "wof:id":1444827749,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Oberstadt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.463998447449914,
+    49.4854750804324,
+    8.463998447449914,
+    49.4854750804324
+],
+  "geometry": {"coordinates":[8.46399844744991,49.4854750804324],"type":"Point"}
+}

--- a/data/144/482/776/3/1444827763.geojson
+++ b/data/144/482/776/3/1444827763.geojson
@@ -26,15 +26,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"1522a6e6ece7d6ecc689531339a6b49b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"2b7bd51f714e04622226f1f78c78eb01",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827763,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827763,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337929,
     "wof:name":"Schlossgebiet",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -42,10 +61,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.462968478669964,
-    49.482687043811644,
-    8.462968478669964,
-    49.482687043811644
+    8.46296847866996,
+    49.48268704381164,
+    8.46296847866996,
+    49.48268704381164
 ],
   "geometry": {"coordinates":[8.46296847866996,49.48268704381164],"type":"Point"}
 }

--- a/data/144/482/776/3/1444827763.geojson
+++ b/data/144/482/776/3/1444827763.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444827763,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.46296847867,49.4826870438,8.46296847867,49.4826870438",
+    "geom:latitude":49.482687,
+    "geom:longitude":8.462968,
+    "iso:country":"DE",
+    "lbl:latitude":49.482687,
+    "lbl:longitude":8.462968,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Schlossgebiet"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"1522a6e6ece7d6ecc689531339a6b49b",
+    "wof:hierarchy":[],
+    "wof:id":1444827763,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Schlossgebiet",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.462968478669964,
+    49.482687043811644,
+    8.462968478669964,
+    49.482687043811644
+],
+  "geometry": {"coordinates":[8.46296847866996,49.48268704381164],"type":"Point"}
+}

--- a/data/144/482/777/3/1444827773.geojson
+++ b/data/144/482/777/3/1444827773.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"c7a2bee2c98b548b9a765ea80d45c910",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1e34a760a382263702825d387147552c",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827773,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827773,
-    "wof:lastmodified":1566334551,
+    "wof:lastmodified":1566337930,
     "wof:name":"Schwetzingerstadt",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.480077404514681,
+    8.48007740451468,
     49.47670151691885,
-    8.480077404514681,
+    8.48007740451468,
     49.47670151691885
 ],
   "geometry": {"coordinates":[8.48007740451468,49.47670151691885],"type":"Point"}

--- a/data/144/482/777/3/1444827773.geojson
+++ b/data/144/482/777/3/1444827773.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827773,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.48007740451,49.4767015169,8.48007740451,49.4767015169",
+    "geom:latitude":49.476702,
+    "geom:longitude":8.480077,
+    "iso:country":"DE",
+    "lbl:latitude":49.476701,
+    "lbl:longitude":8.480077,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Schwetzingerstadt"
+    ],
+    "name:eng_x_preferred":[
+        "Schwetzingerstadt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"c7a2bee2c98b548b9a765ea80d45c910",
+    "wof:hierarchy":[],
+    "wof:id":1444827773,
+    "wof:lastmodified":1566334551,
+    "wof:name":"Schwetzingerstadt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.480077404514681,
+    49.47670151691885,
+    8.480077404514681,
+    49.47670151691885
+],
+  "geometry": {"coordinates":[8.48007740451468,49.47670151691885],"type":"Point"}
+}

--- a/data/144/482/777/7/1444827777.geojson
+++ b/data/144/482/777/7/1444827777.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827777,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.48625721719,49.4836907553,8.48625721719,49.4836907553",
+    "geom:latitude":49.483691,
+    "geom:longitude":8.486257,
+    "iso:country":"DE",
+    "lbl:latitude":49.483691,
+    "lbl:longitude":8.486257,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Oststadt"
+    ],
+    "name:eng_x_preferred":[
+        "Oststadt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"b03edb0b1b70e5adc715198906b09f53",
+    "wof:hierarchy":[],
+    "wof:id":1444827777,
+    "wof:lastmodified":1566334551,
+    "wof:name":"Oststadt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.486257217194378,
+    49.48369075528387,
+    8.486257217194378,
+    49.48369075528387
+],
+  "geometry": {"coordinates":[8.48625721719438,49.48369075528387],"type":"Point"}
+}

--- a/data/144/482/777/7/1444827777.geojson
+++ b/data/144/482/777/7/1444827777.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"b03edb0b1b70e5adc715198906b09f53",
-    "wof:hierarchy":[],
+    "wof:geomhash":"91067a1bcd36c207cb766ee0afe1df84",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827777,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827777,
-    "wof:lastmodified":1566334551,
+    "wof:lastmodified":1566337930,
     "wof:name":"Oststadt",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.486257217194378,
+    8.48625721719438,
     49.48369075528387,
-    8.486257217194378,
+    8.48625721719438,
     49.48369075528387
 ],
   "geometry": {"coordinates":[8.48625721719438,49.48369075528387],"type":"Point"}

--- a/data/144/482/779/1/1444827791.geojson
+++ b/data/144/482/779/1/1444827791.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827791,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.52150503766,49.4737270781,8.52150503766,49.4737270781",
+    "geom:latitude":49.473727,
+    "geom:longitude":8.521505,
+    "iso:country":"DE",
+    "lbl:latitude":49.473727,
+    "lbl:longitude":8.521505,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Neuostheim"
+    ],
+    "name:eng_x_preferred":[
+        "Neuostheim"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"8bdb3a77c06cd104b0cbd7df24b3cc4d",
+    "wof:hierarchy":[],
+    "wof:id":1444827791,
+    "wof:lastmodified":1566334551,
+    "wof:name":"Neuostheim",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.521505037663763,
+    49.473727078094434,
+    8.521505037663763,
+    49.473727078094434
+],
+  "geometry": {"coordinates":[8.52150503766376,49.47372707809443],"type":"Point"}
+}

--- a/data/144/482/779/1/1444827791.geojson
+++ b/data/144/482/779/1/1444827791.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"8bdb3a77c06cd104b0cbd7df24b3cc4d",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ff501502062042f09749bff845b6fa1f",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827791,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827791,
-    "wof:lastmodified":1566334551,
+    "wof:lastmodified":1566337933,
     "wof:name":"Neuostheim",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.521505037663763,
-    49.473727078094434,
-    8.521505037663763,
-    49.473727078094434
+    8.52150503766376,
+    49.47372707809443,
+    8.52150503766376,
+    49.47372707809443
 ],
   "geometry": {"coordinates":[8.52150503766376,49.47372707809443],"type":"Point"}
 }

--- a/data/144/482/779/7/1444827797.geojson
+++ b/data/144/482/779/7/1444827797.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827797,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.50548330109,49.4670339181,8.50548330109,49.4670339181",
+    "geom:latitude":49.467034,
+    "geom:longitude":8.505483,
+    "iso:country":"DE",
+    "lbl:latitude":49.467034,
+    "lbl:longitude":8.505483,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Neuhermsheim"
+    ],
+    "name:eng_x_preferred":[
+        "Neuhermsheim"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"1c3b823e41b7f2b4930a7b22682e163b",
+    "wof:hierarchy":[],
+    "wof:id":1444827797,
+    "wof:lastmodified":1566334551,
+    "wof:name":"Neuhermsheim",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.50548330108677,
+    49.46703391807805,
+    8.50548330108677,
+    49.46703391807805
+],
+  "geometry": {"coordinates":[8.50548330108677,49.46703391807805],"type":"Point"}
+}

--- a/data/144/482/779/7/1444827797.geojson
+++ b/data/144/482/779/7/1444827797.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
     "wof:geomhash":"1c3b823e41b7f2b4930a7b22682e163b",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827797,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827797,
-    "wof:lastmodified":1566334551,
+    "wof:lastmodified":1566337934,
     "wof:name":"Neuhermsheim",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],

--- a/data/144/482/780/1/1444827801.geojson
+++ b/data/144/482/780/1/1444827801.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"2c0a6cdc4657c82b03c4fb9651ee2743",
-    "wof:hierarchy":[],
+    "wof:geomhash":"6c7a5effb742eb2e5e57b7307e3530a4",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827801,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827801,
-    "wof:lastmodified":1566334551,
+    "wof:lastmodified":1566337935,
     "wof:name":"Hochstatt",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.536096262046383,
-    49.455002523380465,
-    8.536096262046383,
-    49.455002523380465
+    8.53609626204638,
+    49.45500252338046,
+    8.53609626204638,
+    49.45500252338046
 ],
   "geometry": {"coordinates":[8.53609626204638,49.45500252338046],"type":"Point"}
 }

--- a/data/144/482/780/1/1444827801.geojson
+++ b/data/144/482/780/1/1444827801.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827801,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.53609626205,49.4550025234,8.53609626205,49.4550025234",
+    "geom:latitude":49.455003,
+    "geom:longitude":8.536096,
+    "iso:country":"DE",
+    "lbl:latitude":49.455002,
+    "lbl:longitude":8.536096,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Hochstatt"
+    ],
+    "name:eng_x_preferred":[
+        "Hochstatt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"2c0a6cdc4657c82b03c4fb9651ee2743",
+    "wof:hierarchy":[],
+    "wof:id":1444827801,
+    "wof:lastmodified":1566334551,
+    "wof:name":"Hochstatt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.536096262046383,
+    49.455002523380465,
+    8.536096262046383,
+    49.455002523380465
+],
+  "geometry": {"coordinates":[8.53609626204638,49.45500252338046],"type":"Point"}
+}

--- a/data/144/482/781/5/1444827815.geojson
+++ b/data/144/482/781/5/1444827815.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"2f1a33d0af7cf36ce851aad1e35fd5bc",
-    "wof:hierarchy":[],
+    "wof:geomhash":"99378d2e0bee958e98a6b6e4c2fdf640",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827815,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827815,
-    "wof:lastmodified":1566334551,
+    "wof:lastmodified":1566337935,
     "wof:name":"Seckenheim",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.557954488376426,
+    8.55795448837643,
     49.46478406728213,
-    8.557954488376426,
+    8.55795448837643,
     49.46478406728213
 ],
   "geometry": {"coordinates":[8.55795448837643,49.46478406728213],"type":"Point"}

--- a/data/144/482/781/5/1444827815.geojson
+++ b/data/144/482/781/5/1444827815.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827815,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.55795448838,49.4647840673,8.55795448838,49.4647840673",
+    "geom:latitude":49.464784,
+    "geom:longitude":8.557954,
+    "iso:country":"DE",
+    "lbl:latitude":49.464784,
+    "lbl:longitude":8.557954,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Seckenheim"
+    ],
+    "name:eng_x_preferred":[
+        "Seckenheim"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"2f1a33d0af7cf36ce851aad1e35fd5bc",
+    "wof:hierarchy":[],
+    "wof:id":1444827815,
+    "wof:lastmodified":1566334551,
+    "wof:name":"Seckenheim",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.557954488376426,
+    49.46478406728213,
+    8.557954488376426,
+    49.46478406728213
+],
+  "geometry": {"coordinates":[8.55795448837643,49.46478406728213],"type":"Point"}
+}

--- a/data/144/482/782/7/1444827827.geojson
+++ b/data/144/482/782/7/1444827827.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827827,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.57546395764,49.4416473784,8.57546395764,49.4416473784",
+    "geom:latitude":49.441647,
+    "geom:longitude":8.575464,
+    "iso:country":"DE",
+    "lbl:latitude":49.441647,
+    "lbl:longitude":8.575464,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Friedrichsfeld"
+    ],
+    "name:eng_x_preferred":[
+        "Friedrichsfeld"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"1414258a033058c10af83df6d8883131",
+    "wof:hierarchy":[],
+    "wof:id":1444827827,
+    "wof:lastmodified":1566334551,
+    "wof:name":"Friedrichsfeld",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.575463957635572,
+    49.44164737836133,
+    8.575463957635572,
+    49.44164737836133
+],
+  "geometry": {"coordinates":[8.57546395763557,49.44164737836133],"type":"Point"}
+}

--- a/data/144/482/782/7/1444827827.geojson
+++ b/data/144/482/782/7/1444827827.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"1414258a033058c10af83df6d8883131",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d490226dc31a385a792241ced2fd92d1",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827827,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827827,
-    "wof:lastmodified":1566334551,
+    "wof:lastmodified":1566337938,
     "wof:name":"Friedrichsfeld",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.575463957635572,
+    8.57546395763557,
     49.44164737836133,
-    8.575463957635572,
+    8.57546395763557,
     49.44164737836133
 ],
   "geometry": {"coordinates":[8.57546395763557,49.44164737836133],"type":"Point"}

--- a/data/144/482/783/3/1444827833.geojson
+++ b/data/144/482/783/3/1444827833.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827833,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.47006381915,49.4709197807,8.47006381915,49.4709197807",
+    "geom:latitude":49.47092,
+    "geom:longitude":8.470064,
+    "iso:country":"DE",
+    "lbl:latitude":49.47092,
+    "lbl:longitude":8.470064,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Lindenhof"
+    ],
+    "name:eng_x_preferred":[
+        "Lindenhof"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"6ffe786f24f7232e2f68733c3735d2ed",
+    "wof:hierarchy":[],
+    "wof:id":1444827833,
+    "wof:lastmodified":1566334551,
+    "wof:name":"Lindenhof",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.470063819154062,
+    49.470919780655656,
+    8.470063819154062,
+    49.470919780655656
+],
+  "geometry": {"coordinates":[8.47006381915406,49.47091978065566],"type":"Point"}
+}

--- a/data/144/482/783/3/1444827833.geojson
+++ b/data/144/482/783/3/1444827833.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"6ffe786f24f7232e2f68733c3735d2ed",
-    "wof:hierarchy":[],
+    "wof:geomhash":"2eeca614c2a046ce2594dccb1dfffce0",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827833,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827833,
-    "wof:lastmodified":1566334551,
+    "wof:lastmodified":1566337939,
     "wof:name":"Lindenhof",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.470063819154062,
-    49.470919780655656,
-    8.470063819154062,
-    49.470919780655656
+    8.47006381915406,
+    49.47091978065566,
+    8.47006381915406,
+    49.47091978065566
 ],
   "geometry": {"coordinates":[8.47006381915406,49.47091978065566],"type":"Point"}
 }

--- a/data/144/482/784/1/1444827841.geojson
+++ b/data/144/482/784/1/1444827841.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827841,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.46640170794,49.4619948526,8.46640170794,49.4619948526",
+    "geom:latitude":49.461995,
+    "geom:longitude":8.466402,
+    "iso:country":"DE",
+    "lbl:latitude":49.461995,
+    "lbl:longitude":8.466402,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Lindenhof-Niederfeld"
+    ],
+    "name:eng_x_preferred":[
+        "Lindenhof-Niederfeld"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"c9580e86c70c8483402f78d305f99470",
+    "wof:hierarchy":[],
+    "wof:id":1444827841,
+    "wof:lastmodified":1566334551,
+    "wof:name":"Lindenhof-Niederfeld",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.46640170793646,
+    49.46199485262225,
+    8.46640170793646,
+    49.46199485262225
+],
+  "geometry": {"coordinates":[8.46640170793646,49.46199485262225],"type":"Point"}
+}

--- a/data/144/482/784/1/1444827841.geojson
+++ b/data/144/482/784/1/1444827841.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
     "wof:geomhash":"c9580e86c70c8483402f78d305f99470",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827841,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827841,
-    "wof:lastmodified":1566334551,
+    "wof:lastmodified":1566337940,
     "wof:name":"Lindenhof-Niederfeld",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],

--- a/data/144/482/785/1/1444827851.geojson
+++ b/data/144/482/785/1/1444827851.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827851,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.48494114598,49.4632593163,8.48494114598,49.4632593163",
+    "geom:latitude":49.463259,
+    "geom:longitude":8.484941,
+    "iso:country":"DE",
+    "lbl:latitude":49.463259,
+    "lbl:longitude":8.484941,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Almenhof"
+    ],
+    "name:eng_x_preferred":[
+        "Almenhof"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"8f1534b3d7e5969460c181ecd9a77b86",
+    "wof:hierarchy":[],
+    "wof:id":1444827851,
+    "wof:lastmodified":1566334551,
+    "wof:name":"Almenhof",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.484941145975554,
+    49.46325931627531,
+    8.484941145975554,
+    49.46325931627531
+],
+  "geometry": {"coordinates":[8.48494114597555,49.46325931627531],"type":"Point"}
+}

--- a/data/144/482/785/1/1444827851.geojson
+++ b/data/144/482/785/1/1444827851.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"8f1534b3d7e5969460c181ecd9a77b86",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ba3b6af871e8c1f3504c4883d7cc129e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827851,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827851,
-    "wof:lastmodified":1566334551,
+    "wof:lastmodified":1566337940,
     "wof:name":"Almenhof",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.484941145975554,
+    8.48494114597555,
     49.46325931627531,
-    8.484941145975554,
+    8.48494114597555,
     49.46325931627531
 ],
   "geometry": {"coordinates":[8.48494114597555,49.46325931627531],"type":"Point"}

--- a/data/144/482/786/3/1444827863.geojson
+++ b/data/144/482/786/3/1444827863.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827863,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.47395481232,49.4582012659,8.47395481232,49.4582012659",
+    "geom:latitude":49.458201,
+    "geom:longitude":8.473955,
+    "iso:country":"DE",
+    "lbl:latitude":49.458201,
+    "lbl:longitude":8.473955,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Niederfeld"
+    ],
+    "name:eng_x_preferred":[
+        "Niederfeld"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"c080f5a5e876422c87919bf46ad2d789",
+    "wof:hierarchy":[],
+    "wof:id":1444827863,
+    "wof:lastmodified":1566334551,
+    "wof:name":"Niederfeld",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.47395481232276,
+    49.45820126588125,
+    8.47395481232276,
+    49.45820126588125
+],
+  "geometry": {"coordinates":[8.47395481232276,49.45820126588125],"type":"Point"}
+}

--- a/data/144/482/786/3/1444827863.geojson
+++ b/data/144/482/786/3/1444827863.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
     "wof:geomhash":"c080f5a5e876422c87919bf46ad2d789",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827863,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827863,
-    "wof:lastmodified":1566334551,
+    "wof:lastmodified":1566337943,
     "wof:name":"Niederfeld",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],

--- a/data/144/482/787/3/1444827873.geojson
+++ b/data/144/482/787/3/1444827873.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"297ebf13e3bab067ba2ca659901f20d0",
-    "wof:hierarchy":[],
+    "wof:geomhash":"4952d89bf28480adb35936201d7f03a4",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827873,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827873,
-    "wof:lastmodified":1566334551,
+    "wof:lastmodified":1566337944,
     "wof:name":"Neckerau",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.492150927435201,
+    8.4921509274352,
     49.45425859985423,
-    8.492150927435201,
+    8.4921509274352,
     49.45425859985423
 ],
   "geometry": {"coordinates":[8.4921509274352,49.45425859985423],"type":"Point"}

--- a/data/144/482/787/3/1444827873.geojson
+++ b/data/144/482/787/3/1444827873.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827873,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.49215092744,49.4542585999,8.49215092744,49.4542585999",
+    "geom:latitude":49.454259,
+    "geom:longitude":8.492151,
+    "iso:country":"DE",
+    "lbl:latitude":49.454259,
+    "lbl:longitude":8.492151,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Neckerau"
+    ],
+    "name:eng_x_preferred":[
+        "Neckerau"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"297ebf13e3bab067ba2ca659901f20d0",
+    "wof:hierarchy":[],
+    "wof:id":1444827873,
+    "wof:lastmodified":1566334551,
+    "wof:name":"Neckerau",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.492150927435201,
+    49.45425859985423,
+    8.492150927435201,
+    49.45425859985423
+],
+  "geometry": {"coordinates":[8.4921509274352,49.45425859985423],"type":"Point"}
+}

--- a/data/144/482/788/3/1444827883.geojson
+++ b/data/144/482/788/3/1444827883.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827883,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.52937285473,49.4322891658,8.52937285473,49.4322891658",
+    "geom:latitude":49.432289,
+    "geom:longitude":8.529373,
+    "iso:country":"DE",
+    "lbl:latitude":49.432289,
+    "lbl:longitude":8.529373,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Rheinau"
+    ],
+    "name:eng_x_preferred":[
+        "Rheinau"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"6ad1cf4ba95256c616ae6989d3d1de6d",
+    "wof:hierarchy":[],
+    "wof:id":1444827883,
+    "wof:lastmodified":1566334551,
+    "wof:name":"Rheinau",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.529372854732825,
+    49.432289165836664,
+    8.529372854732825,
+    49.432289165836664
+],
+  "geometry": {"coordinates":[8.52937285473283,49.43228916583666],"type":"Point"}
+}

--- a/data/144/482/788/3/1444827883.geojson
+++ b/data/144/482/788/3/1444827883.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"6ad1cf4ba95256c616ae6989d3d1de6d",
-    "wof:hierarchy":[],
+    "wof:geomhash":"bf406b6c2b0847d8c55cdb474c3d2ba3",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827883,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827883,
-    "wof:lastmodified":1566334551,
+    "wof:lastmodified":1566337945,
     "wof:name":"Rheinau",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.529372854732825,
-    49.432289165836664,
-    8.529372854732825,
-    49.432289165836664
+    8.52937285473283,
+    49.43228916583666,
+    8.52937285473283,
+    49.43228916583666
 ],
   "geometry": {"coordinates":[8.52937285473283,49.43228916583666],"type":"Point"}
 }

--- a/data/144/482/789/3/1444827893.geojson
+++ b/data/144/482/789/3/1444827893.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827893,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.51815763913,49.444642375,8.51815763913,49.444642375",
+    "geom:latitude":49.444642,
+    "geom:longitude":8.518158,
+    "iso:country":"DE",
+    "lbl:latitude":49.444642,
+    "lbl:longitude":8.518158,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Casterfeld"
+    ],
+    "name:eng_x_preferred":[
+        "Casterfeld"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"a86131177233cecb4237e88979894402",
+    "wof:hierarchy":[],
+    "wof:id":1444827893,
+    "wof:lastmodified":1566334551,
+    "wof:name":"Casterfeld",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.51815763912893,
+    49.44464237498666,
+    8.51815763912893,
+    49.44464237498666
+],
+  "geometry": {"coordinates":[8.51815763912893,49.44464237498666],"type":"Point"}
+}

--- a/data/144/482/789/3/1444827893.geojson
+++ b/data/144/482/789/3/1444827893.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
     "wof:geomhash":"a86131177233cecb4237e88979894402",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827893,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827893,
-    "wof:lastmodified":1566334551,
+    "wof:lastmodified":1566337945,
     "wof:name":"Casterfeld",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],

--- a/data/144/482/790/5/1444827905.geojson
+++ b/data/144/482/790/5/1444827905.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
     "wof:geomhash":"6e7b4cc99e2b1725173f62a253787889",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827905,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827905,
-    "wof:lastmodified":1566334551,
+    "wof:lastmodified":1566337948,
     "wof:name":"Mallau",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],

--- a/data/144/482/790/5/1444827905.geojson
+++ b/data/144/482/790/5/1444827905.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827905,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.51758543425,49.4520825587,8.51758543425,49.4520825587",
+    "geom:latitude":49.452083,
+    "geom:longitude":8.517585,
+    "iso:country":"DE",
+    "lbl:latitude":49.452083,
+    "lbl:longitude":8.517585,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Mallau"
+    ],
+    "name:eng_x_preferred":[
+        "Mallau"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"6e7b4cc99e2b1725173f62a253787889",
+    "wof:hierarchy":[],
+    "wof:id":1444827905,
+    "wof:lastmodified":1566334551,
+    "wof:name":"Mallau",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.51758543425118,
+    49.45208255872491,
+    8.51758543425118,
+    49.45208255872491
+],
+  "geometry": {"coordinates":[8.51758543425118,49.45208255872491],"type":"Point"}
+}

--- a/data/144/482/791/7/1444827917.geojson
+++ b/data/144/482/791/7/1444827917.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827917,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.53337828888,49.4444935569,8.53337828888,49.4444935569",
+    "geom:latitude":49.444494,
+    "geom:longitude":8.533378,
+    "iso:country":"DE",
+    "lbl:latitude":49.444494,
+    "lbl:longitude":8.533378,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Pfingstberg"
+    ],
+    "name:eng_x_preferred":[
+        "Pfingstberg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"7546d6c2ca0ba17a73644740859a1f27",
+    "wof:hierarchy":[],
+    "wof:id":1444827917,
+    "wof:lastmodified":1566334551,
+    "wof:name":"Pfingstberg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.533378288877072,
+    49.444493556915035,
+    8.533378288877072,
+    49.444493556915035
+],
+  "geometry": {"coordinates":[8.53337828887707,49.44449355691503],"type":"Point"}
+}

--- a/data/144/482/791/7/1444827917.geojson
+++ b/data/144/482/791/7/1444827917.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"7546d6c2ca0ba17a73644740859a1f27",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e1b58124c6cd8afdddd777a6b2510b07",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827917,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827917,
-    "wof:lastmodified":1566334551,
+    "wof:lastmodified":1566337949,
     "wof:name":"Pfingstberg",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.533378288877072,
-    49.444493556915035,
-    8.533378288877072,
-    49.444493556915035
+    8.53337828887707,
+    49.44449355691503,
+    8.53337828887707,
+    49.44449355691503
 ],
   "geometry": {"coordinates":[8.53337828887707,49.44449355691503],"type":"Point"}
 }

--- a/data/144/482/792/7/1444827927.geojson
+++ b/data/144/482/792/7/1444827927.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827927,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.53223387912,49.416136013,8.53223387912,49.416136013",
+    "geom:latitude":49.416136,
+    "geom:longitude":8.532234,
+    "iso:country":"DE",
+    "lbl:latitude":49.416136,
+    "lbl:longitude":8.532234,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Rheinau-S\u00fcd"
+    ],
+    "name:eng_x_preferred":[
+        "Rheinau-Sued"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"9903f784839ae2ffa3368c8187a4ced9",
+    "wof:hierarchy":[],
+    "wof:id":1444827927,
+    "wof:lastmodified":1566334551,
+    "wof:name":"Rheinau-Sued",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.532233879121573,
+    49.4161360129574,
+    8.532233879121573,
+    49.4161360129574
+],
+  "geometry": {"coordinates":[8.53223387912157,49.4161360129574],"type":"Point"}
+}

--- a/data/144/482/792/7/1444827927.geojson
+++ b/data/144/482/792/7/1444827927.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"9903f784839ae2ffa3368c8187a4ced9",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ba09b8bea73bf7db6fee720b8937e12b",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444827927,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444827927,
-    "wof:lastmodified":1566334551,
+    "wof:lastmodified":1566337950,
     "wof:name":"Rheinau-Sued",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.532233879121573,
+    8.53223387912157,
     49.4161360129574,
-    8.532233879121573,
+    8.53223387912157,
     49.4161360129574
 ],
   "geometry": {"coordinates":[8.53223387912157,49.4161360129574],"type":"Point"}

--- a/data/144/483/876/5/1444838765.geojson
+++ b/data/144/483/876/5/1444838765.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838765,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.44900667965,49.5837354304,8.44900667965,49.5837354304",
+    "geom:latitude":49.583735,
+    "geom:longitude":8.449007,
+    "iso:country":"DE",
+    "lbl:latitude":49.583735,
+    "lbl:longitude":8.449007,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Kirschgartshausen"
+    ],
+    "name:eng_x_preferred":[
+        "Kirschgartshausen"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"6666896b83c1214751e2af139ce9ffb6",
+    "wof:hierarchy":[],
+    "wof:id":1444838765,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Kirschgartshausen",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.449006679652868,
+    49.5837354303587,
+    8.449006679652868,
+    49.5837354303587
+],
+  "geometry": {"coordinates":[8.44900667965287,49.5837354303587],"type":"Point"}
+}

--- a/data/144/483/876/5/1444838765.geojson
+++ b/data/144/483/876/5/1444838765.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"6666896b83c1214751e2af139ce9ffb6",
-    "wof:hierarchy":[],
+    "wof:geomhash":"78c69179757842fa73b485c4ee2dbc08",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444838765,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444838765,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337901,
     "wof:name":"Kirschgartshausen",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.449006679652868,
+    8.44900667965287,
     49.5837354303587,
-    8.449006679652868,
+    8.44900667965287,
     49.5837354303587
 ],
   "geometry": {"coordinates":[8.44900667965287,49.5837354303587],"type":"Point"}

--- a/data/144/483/877/3/1444838773.geojson
+++ b/data/144/483/877/3/1444838773.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"b1fae637b80a8e09faf73900a546b185",
-    "wof:hierarchy":[],
+    "wof:geomhash":"9de6a2f43d5dd659f8878f829064b62b",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444838773,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444838773,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337904,
     "wof:name":"Scharhof",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.446488978190768,
-    49.560580720779114,
-    8.446488978190768,
-    49.560580720779114
+    8.44648897819077,
+    49.56058072077911,
+    8.44648897819077,
+    49.56058072077911
 ],
   "geometry": {"coordinates":[8.44648897819077,49.56058072077911],"type":"Point"}
 }

--- a/data/144/483/877/3/1444838773.geojson
+++ b/data/144/483/877/3/1444838773.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838773,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.44648897819,49.5605807208,8.44648897819,49.5605807208",
+    "geom:latitude":49.560581,
+    "geom:longitude":8.446489,
+    "iso:country":"DE",
+    "lbl:latitude":49.560581,
+    "lbl:longitude":8.446489,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Scharhof"
+    ],
+    "name:eng_x_preferred":[
+        "Scharhof"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"b1fae637b80a8e09faf73900a546b185",
+    "wof:hierarchy":[],
+    "wof:id":1444838773,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Scharhof",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.446488978190768,
+    49.560580720779114,
+    8.446488978190768,
+    49.560580720779114
+],
+  "geometry": {"coordinates":[8.44648897819077,49.56058072077911],"type":"Point"}
+}

--- a/data/144/483/878/1/1444838781.geojson
+++ b/data/144/483/878/1/1444838781.geojson
@@ -28,15 +28,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"147d67543a2b31276b24a2f8356b41e1",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f8fe26ff10cca191b719f0b44e308436",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444838781,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444838781,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337904,
     "wof:name":"Blumenau",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -44,9 +63,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.497987417188245,
+    8.49798741718825,
     49.5614714896448,
-    8.497987417188245,
+    8.49798741718825,
     49.5614714896448
 ],
   "geometry": {"coordinates":[8.49798741718825,49.5614714896448],"type":"Point"}

--- a/data/144/483/878/1/1444838781.geojson
+++ b/data/144/483/878/1/1444838781.geojson
@@ -1,0 +1,53 @@
+{
+  "id": 1444838781,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.49798741719,49.5614714896,8.49798741719,49.5614714896",
+    "geom:latitude":49.561471,
+    "geom:longitude":8.497987,
+    "iso:country":"DE",
+    "lbl:latitude":49.561471,
+    "lbl:longitude":8.497987,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Blumenau"
+    ],
+    "name:eng_x_preferred":[
+        "Blumenau"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"147d67543a2b31276b24a2f8356b41e1",
+    "wof:hierarchy":[],
+    "wof:id":1444838781,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Blumenau",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.497987417188245,
+    49.5614714896448,
+    8.497987417188245,
+    49.5614714896448
+],
+  "geometry": {"coordinates":[8.49798741718825,49.5614714896448],"type":"Point"}
+}

--- a/data/144/483/878/5/1444838785.geojson
+++ b/data/144/483/878/5/1444838785.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"e522506f8c0ac9c9de3608c7f5d8ab85",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d0728218b88a50d8f3c7f7966bda2e02",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444838785,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444838785,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337905,
     "wof:name":"Schoenau",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.471208228909557,
+    8.47120822890956,
     49.54409856563165,
-    8.471208228909557,
+    8.47120822890956,
     49.54409856563165
 ],
   "geometry": {"coordinates":[8.47120822890956,49.54409856563165],"type":"Point"}

--- a/data/144/483/878/5/1444838785.geojson
+++ b/data/144/483/878/5/1444838785.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838785,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.47120822891,49.5440985656,8.47120822891,49.5440985656",
+    "geom:latitude":49.544099,
+    "geom:longitude":8.471208,
+    "iso:country":"DE",
+    "lbl:latitude":49.544098,
+    "lbl:longitude":8.471208,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Sch\u00f6nau"
+    ],
+    "name:eng_x_preferred":[
+        "Schoenau"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"e522506f8c0ac9c9de3608c7f5d8ab85",
+    "wof:hierarchy":[],
+    "wof:id":1444838785,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Schoenau",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.471208228909557,
+    49.54409856563165,
+    8.471208228909557,
+    49.54409856563165
+],
+  "geometry": {"coordinates":[8.47120822890956,49.54409856563165],"type":"Point"}
+}

--- a/data/144/483/879/1/1444838791.geojson
+++ b/data/144/483/879/1/1444838791.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"ecec40f1392b28298643dfb654b0089a",
-    "wof:hierarchy":[],
+    "wof:geomhash":"eb67944c67add7106ae2f0a00da8b32d",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444838791,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444838791,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337908,
     "wof:name":"Sandhofen",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.450379971359467,
+    8.45037997135947,
     49.54424707834337,
-    8.450379971359467,
+    8.45037997135947,
     49.54424707834337
 ],
   "geometry": {"coordinates":[8.45037997135947,49.54424707834337],"type":"Point"}

--- a/data/144/483/879/1/1444838791.geojson
+++ b/data/144/483/879/1/1444838791.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838791,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.45037997136,49.5442470783,8.45037997136,49.5442470783",
+    "geom:latitude":49.544247,
+    "geom:longitude":8.45038,
+    "iso:country":"DE",
+    "lbl:latitude":49.544247,
+    "lbl:longitude":8.45038,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Sandhofen"
+    ],
+    "name:eng_x_preferred":[
+        "Sandhofen"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"ecec40f1392b28298643dfb654b0089a",
+    "wof:hierarchy":[],
+    "wof:id":1444838791,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Sandhofen",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.450379971359467,
+    49.54424707834337,
+    8.450379971359467,
+    49.54424707834337
+],
+  "geometry": {"coordinates":[8.45037997135947,49.54424707834337],"type":"Point"}
+}

--- a/data/144/483/879/7/1444838797.geojson
+++ b/data/144/483/879/7/1444838797.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"af6cc9f57273064ff811a230bbbc106f",
-    "wof:hierarchy":[],
+    "wof:geomhash":"95f077dcf30d823838bacdfd416f5522",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444838797,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444838797,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337909,
     "wof:name":"Friesenheimer Insel",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.446717860141868,
+    8.44671786014187,
     49.5210736373745,
-    8.446717860141868,
+    8.44671786014187,
     49.5210736373745
 ],
   "geometry": {"coordinates":[8.44671786014187,49.5210736373745],"type":"Point"}

--- a/data/144/483/879/7/1444838797.geojson
+++ b/data/144/483/879/7/1444838797.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838797,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.44671786014,49.5210736374,8.44671786014,49.5210736374",
+    "geom:latitude":49.521074,
+    "geom:longitude":8.446718,
+    "iso:country":"DE",
+    "lbl:latitude":49.521074,
+    "lbl:longitude":8.446718,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Friesenheimer Insel"
+    ],
+    "name:eng_x_preferred":[
+        "Friesenheimer Insel"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"af6cc9f57273064ff811a230bbbc106f",
+    "wof:hierarchy":[],
+    "wof:id":1444838797,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Friesenheimer Insel",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.446717860141868,
+    49.5210736373745,
+    8.446717860141868,
+    49.5210736373745
+],
+  "geometry": {"coordinates":[8.44671786014187,49.5210736373745],"type":"Point"}
+}

--- a/data/144/483/880/3/1444838803.geojson
+++ b/data/144/483/880/3/1444838803.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"4d4f691fc03b1a7a53422cecf6e95468",
-    "wof:hierarchy":[],
+    "wof:geomhash":"3fb419b4da6d50c7aa4f4c7446bad948",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444838803,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444838803,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337910,
     "wof:name":"Waldhof",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.481965680611253,
-    49.526868027615755,
-    8.481965680611253,
-    49.526868027615755
+    8.48196568061125,
+    49.52686802761576,
+    8.48196568061125,
+    49.52686802761576
 ],
   "geometry": {"coordinates":[8.48196568061125,49.52686802761576],"type":"Point"}
 }

--- a/data/144/483/880/3/1444838803.geojson
+++ b/data/144/483/880/3/1444838803.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838803,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.48196568061,49.5268680276,8.48196568061,49.5268680276",
+    "geom:latitude":49.526868,
+    "geom:longitude":8.481966,
+    "iso:country":"DE",
+    "lbl:latitude":49.526868,
+    "lbl:longitude":8.481966,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Waldhof"
+    ],
+    "name:eng_x_preferred":[
+        "Waldhof"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"4d4f691fc03b1a7a53422cecf6e95468",
+    "wof:hierarchy":[],
+    "wof:id":1444838803,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Waldhof",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.481965680611253,
+    49.526868027615755,
+    8.481965680611253,
+    49.526868027615755
+],
+  "geometry": {"coordinates":[8.48196568061125,49.52686802761576],"type":"Point"}
+}

--- a/data/144/483/881/1/1444838811.geojson
+++ b/data/144/483/881/1/1444838811.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"ca52acd95d3b1bdb3cd780e90f260295",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1ed36dc004fbb8bce821fe459147d8ae",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444838811,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444838811,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337910,
     "wof:name":"Speckweggebiet",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.496957448408297,
+    8.4969574484083,
     49.52062788457356,
-    8.496957448408297,
+    8.4969574484083,
     49.52062788457356
 ],
   "geometry": {"coordinates":[8.4969574484083,49.52062788457356],"type":"Point"}

--- a/data/144/483/881/1/1444838811.geojson
+++ b/data/144/483/881/1/1444838811.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838811,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.49695744841,49.5206278846,8.49695744841,49.5206278846",
+    "geom:latitude":49.520628,
+    "geom:longitude":8.496957,
+    "iso:country":"DE",
+    "lbl:latitude":49.520628,
+    "lbl:longitude":8.496957,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Speckweggebiet"
+    ],
+    "name:eng_x_preferred":[
+        "Speckweggebiet"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"ca52acd95d3b1bdb3cd780e90f260295",
+    "wof:hierarchy":[],
+    "wof:id":1444838811,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Speckweggebiet",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.496957448408297,
+    49.52062788457356,
+    8.496957448408297,
+    49.52062788457356
+],
+  "geometry": {"coordinates":[8.4969574484083,49.52062788457356],"type":"Point"}
+}

--- a/data/144/483/881/7/1444838817.geojson
+++ b/data/144/483/881/7/1444838817.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85682567,
+        102191581,
+        85633111,
+        1377688443,
+        404227555,
+        101748549,
+        102063473
+    ],
     "wof:breaches":[],
     "wof:country":"DE",
-    "wof:geomhash":"9f25871bb14c541d884f3936b7dee45b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"2557e528c25288c753b06b875ea32fbd",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633111,
+            "county_id":102063473,
+            "localadmin_id":1377688443,
+            "locality_id":101748549,
+            "macrocounty_id":404227555,
+            "neighbourhood_id":1444838817,
+            "region_id":85682567
+        }
+    ],
     "wof:id":1444838817,
-    "wof:lastmodified":1566334550,
+    "wof:lastmodified":1566337913,
     "wof:name":"Luzenberg",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748549,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.479333538173604,
+    8.4793335381736,
     49.51795329665902,
-    8.479333538173604,
+    8.4793335381736,
     49.51795329665902
 ],
   "geometry": {"coordinates":[8.4793335381736,49.51795329665902],"type":"Point"}

--- a/data/144/483/881/7/1444838817.geojson
+++ b/data/144/483/881/7/1444838817.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838817,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"8.47933353817,49.5179532967,8.47933353817,49.5179532967",
+    "geom:latitude":49.517953,
+    "geom:longitude":8.479334,
+    "iso:country":"DE",
+    "lbl:latitude":49.517953,
+    "lbl:longitude":8.479334,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Luzenberg"
+    ],
+    "name:eng_x_preferred":[
+        "Luzenberg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"DE",
+    "wof:geomhash":"9f25871bb14c541d884f3936b7dee45b",
+    "wof:hierarchy":[],
+    "wof:id":1444838817,
+    "wof:lastmodified":1566334550,
+    "wof:name":"Luzenberg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-de",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    8.479333538173604,
+    49.51795329665902,
+    8.479333538173604,
+    49.51795329665902
+],
+  "geometry": {"coordinates":[8.4793335381736,49.51795329665902],"type":"Point"}
+}


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1695.

This PR contains new neighbourhood records from Nat's neighbourhood import file. 