### PR TITLE
Add wikidata concordance to Bavaria region record

### DIFF
--- a/data/856/825/71/85682571.geojson
+++ b/data/856/825/71/85682571.geojson
@@ -602,7 +602,8 @@
         "gp:id":2345482,
         "hasc:id":"DE.BY",
         "iso:id":"DE-BY",
-        "unlc:id":"DE-BY"
+        "unlc:id":"DE-BY",
+        "wd:id":"Q980"
     },
     "wof:country":"DE",
     "wof:geom_alt":[

--- a/data/856/825/71/85682571.geojson
+++ b/data/856/825/71/85682571.geojson
@@ -625,7 +625,7 @@
     "wof:lang_x_spoken":[
         "deu"
     ],
-    "wof:lastmodified":1607462675,
+    "wof:lastmodified":1619136933,
     "wof:name":"Bavaria",
     "wof:parent_id":85633111,
     "wof:placetype":"region",


### PR DESCRIPTION
Replaces https://github.com/whosonfirst-data/whosonfirst-data-admin-de/pull/39

Adds a wikidata concordacne to the regionn record of Bavaria, exportifies the record to validate changes.
No PIP work required, can merge as-is.