### PR TITLE
Update berlin locality

### DIFF
--- a/data/101/748/799/101748799.geojson
+++ b/data/101/748/799/101748799.geojson
@@ -2,7 +2,7 @@
   "id": 101748799,
   "type": "Feature",
   "properties": {
-    "edtf:cessation":"uuuu",
+    "edtf:cessation":"2022-05-25",
     "edtf:inception":"uuuu",
     "geom:area":0.117924,
     "geom:area_square_m":887634019.058632,
@@ -19,7 +19,7 @@
     "mps:latitude":52.500778,
     "mps:longitude":13.378153,
     "mz:hierarchy_label":1,
-    "mz:is_current":1,
+    "mz:is_current":0,
     "mz:min_zoom":2.7,
     "name:abk_x_preferred":[
         "\u0411\u0435\u0440\u043b\u0438\u043d"
@@ -945,8 +945,8 @@
     "wof:belongsto":[
         102191581,
         85633111,
-        85682499,
-        102063945
+        102063945,
+        85682499
     ],
     "wof:breaches":[],
     "wof:capital_of":[
@@ -981,7 +981,7 @@
         }
     ],
     "wof:id":101748799,
-    "wof:lastmodified":1617131307,
+    "wof:lastmodified":1653511044,
     "wof:megacity":1,
     "wof:name":"Berlin",
     "wof:parent_id":102063945,

--- a/data/101/909/779/101909779.geojson
+++ b/data/101/909/779/101909779.geojson
@@ -888,7 +888,8 @@
         }
     ],
     "wof:id":101909779,
-    "wof:lastmodified":1608049140,
+    "wof:lastmodified":1653517063,
+    "wof:megacity":1,
     "wof:name":"Berlin",
     "wof:parent_id":1377694153,
     "wof:placetype":"locality",


### PR DESCRIPTION
Records at all placetypes in Germany were updated a few years ago with new open data. During that work, two different Berlin locality records were found and updated.. 

- https://spelunker.whosonfirst.org/id/101909779
- https://spelunker.whosonfirst.org/id/101748799

101748799 was superseded into 101909779, but (incorrectly) 101748799 was never given an updated `edtf:` or `mz:is_current` property. This PR updates those properties in 101748799.

Because the superseded_by property is filled in on 101748799, this place was skipped over when building descendant hierarchies.. so there shouldn't be any PIP work needed here. Can merge as-is once approved.