### PR TITLE
Fix name property name

### DIFF
--- a/data/139/359/646/5/1393596465.geojson
+++ b/data/139/359/646/5/1393596465.geojson
@@ -87,11 +87,11 @@
     "name:kir_x_variant":[
         "\u0411\u0430\u043b\u044c\u0434\u0435\u0440\u0448\u0432\u0430\u043d\u0433"
     ],
-    "name:lat_x_":[
-        "Balderschwang"
-    ],
     "name:lat_x_preferred":[
         "Gamerschwang"
+    ],
+    "name:lat_x_variant":[
+        "Balderschwang"
     ],
     "name:lmo_x_preferred":[
         "Gamerschwang"
@@ -222,7 +222,7 @@
         }
     ],
     "wof:id":1393596465,
-    "wof:lastmodified":1624915670,
+    "wof:lastmodified":1654549562,
     "wof:name":"Balderschwang",
     "wof:parent_id":101764347,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/2003.

This PR corrects a name property addition added through https://github.com/whosonfirst-data/whosonfirst-data-admin-de/commit/4f32a0dad76fb07160cdd4660d4ed2e250316beb.

No PIP work needed, can merge once approved.