### PR TITLE
Update Elmsbuettel record

### DIFF
--- a/data/110/894/007/1/1108940071.geojson
+++ b/data/110/894/007/1/1108940071.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"9.92988065068,53.6087750322,9.92988065068,53.6087750322",
+    "geom:bbox":"9.929881,53.608775,9.929881,53.608775",
     "geom:latitude":53.608775,
     "geom:longitude":9.929881,
     "iso:country":"DE",
@@ -15,7 +15,7 @@
     "lbl:longitude":9.929881,
     "lbl:max_zoom":18.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:is_funky":0,
     "mz:is_hard_boundary":0,
     "mz:is_landuse_aoi":0,
@@ -25,22 +25,34 @@
     "mz:note":"stadtbezirk",
     "mz:tier_metro":30,
     "name:deu_x_preferred":[
+        "Eimsb\u00fcttel"
+    ],
+    "name:deu_x_variant":[
         "Elmsb\u00fcttel"
     ],
+    "name:eng_x_preferred":[
+        "Eimsbuttel"
+    ],
+    "name:eng_x_variant":[
+        "Elmsbuettel"
+    ],
+    "src:geom":"unknown",
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191581,
-        1377684829,
         85633111,
-        101748841,
         102064053,
+        1377684829,
+        101748841,
         85682505
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "wd:id":"Q1632"
+    },
     "wof:country":"DE",
     "wof:created":1491361507,
-    "wof:geomhash":"8544a821c8917cc07b73db65ca9e990e",
+    "wof:geomhash":"48d3663431779d1b2d8eee422bfe9b09",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -53,8 +65,8 @@
         }
     ],
     "wof:id":1108940071,
-    "wof:lastmodified":1566712975,
-    "wof:name":"Elmsbuettel",
+    "wof:lastmodified":1667333514,
+    "wof:name":"Eimsbuttel",
     "wof:parent_id":101748841,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",
@@ -63,10 +75,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    9.92988065068326,
-    53.60877503224963,
-    9.92988065068326,
-    53.60877503224963
+    9.929881,
+    53.608775,
+    9.929881,
+    53.608775
 ],
-  "geometry": {"coordinates":[9.92988065068326,53.60877503224963],"type":"Point"}
+  "geometry": {"coordinates":[9.929881,53.608775],"type":"Point"}
 }


### PR DESCRIPTION
Replaces https://github.com/whosonfirst-data/whosonfirst-data-admin-de/pull/76

This PR updates names, is_current, and concordances on the Elmsbuettel record in this repo.