### PR TITLE
Revert superseding of Forchheim

### DIFF
--- a/data/101/827/055/101827055.geojson
+++ b/data/101/827/055/101827055.geojson
@@ -383,7 +383,7 @@
         }
     ],
     "wof:id":101827055,
-    "wof:lastmodified":1608049810,
+    "wof:lastmodified":1675971390,
     "wof:name":"Forchheim",
     "wof:parent_id":1377687895,
     "wof:placetype":"locality",
@@ -393,8 +393,7 @@
     "wof:superseded_by":[],
     "wof:supersedes":[
         1125301973,
-        1125285307,
-        1343563669
+        1125285307
     ],
     "wof:tags":[]
 },

--- a/data/134/356/366/9/1343563669.geojson
+++ b/data/134/356/366/9/1343563669.geojson
@@ -3,7 +3,6 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
-    "edtf:deprecated":"2019-05-20",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -28,14 +27,14 @@
     "gn:timezone":"Europe/Berlin",
     "iso:country":"DE",
     "mz:hierarchy_label":1,
-    "mz:is_current":0,
+    "mz:is_current":1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85682571,
         102191581,
         85633111,
+        102063439,
         404227545,
-        102063439
+        85682571
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,14 +53,12 @@
         }
     ],
     "wof:id":1343563669,
-    "wof:lastmodified":1558387063,
+    "wof:lastmodified":1675971387,
     "wof:name":"Forchheim",
     "wof:parent_id":102063439,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-de",
-    "wof:superseded_by":[
-        101827055
-    ],
+    "wof:superseded_by":[],
     "wof:supersedes":[],
     "wof:tags":[]
 },


### PR DESCRIPTION
Will fix https://github.com/whosonfirst-data/whosonfirst-data/issues/2023

This PR reverts a superseding link between two (unique) Forchheim records. These records were incorrectly flagged as duplicates and superseded through a larger update of admin data in this repo; reverting the supersedes/superseded_by properties should fix this issue.

No PIP work required.