### PR TITLE
add "wof:lang_x_official" and "wof:lang_x_spoken"

### DIFF
--- a/data/102/063/273/102063273.geojson
+++ b/data/102/063/273/102063273.geojson
@@ -94,6 +94,12 @@
         }
     ],
     "wof:id":102063273,
+    "wof:lang_x_official":[
+        "deu"
+    ],
+    "wof:lang_x_spoken":[
+        "deu"
+    ],
     "wof:lastmodified":1627522031,
     "wof:name":"M\u00fcnchen",
     "wof:parent_id":404227567,


### PR DESCRIPTION
Since Pelias relies on "wof:lang_x_official" it looks a little bit weird seeing a german county with an english name

Example: https://pelias.github.io/compare/#/v1/autocomplete?lang=de&text=M%C3%BCnchen+District&debug=1