### PR TITLE
Update lang properties

### DIFF
--- a/data/102/063/273/102063273.geojson
+++ b/data/102/063/273/102063273.geojson
@@ -71,8 +71,8 @@
     "statoids:type":"rural district",
     "wof:belongsto":[
         102191581,
-        404227567,
         85633111,
+        404227567,
         85682571
     ],
     "wof:breaches":[],
@@ -100,7 +100,7 @@
     "wof:lang_x_spoken":[
         "deu"
     ],
-    "wof:lastmodified":1627522031,
+    "wof:lastmodified":1676663090,
     "wof:name":"M\u00fcnchen",
     "wof:parent_id":404227567,
     "wof:placetype":"county",

--- a/data/102/063/273/102063273.geojson
+++ b/data/102/063/273/102063273.geojson
@@ -94,6 +94,12 @@
         }
     ],
     "wof:id":102063273,
+    "wof:lang_x_official":[
+        "deu"
+    ],
+    "wof:lang_x_spoken":[
+        "deu"
+    ],
     "wof:lastmodified":1627522031,
     "wof:name":"M\u00fcnchen",
     "wof:parent_id":404227567,


### PR DESCRIPTION
Replaces https://github.com/whosonfirst-data/whosonfirst-data-admin-de/pull/84 and exportifies the record to validate the changes. This PR adds `wof:lang_*` properties to the admin2 record for Munich.

No PIP work needed, can merge as-is.