### PR TITLE
Update Esch neighbourhood

### DIFF
--- a/data/137/780/259/7/1377802597.geojson
+++ b/data/137/780/259/7/1377802597.geojson
@@ -29,91 +29,148 @@
     "lbl:bbox":"6.53942,50.93769,6.54942,50.94769",
     "lbl:max_zoom":18.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":15.0,
     "name:ceb_x_preferred":[
+        "Esch"
+    ],
+    "name:ceb_x_variant":[
         "Esche"
     ],
     "name:deu_x_preferred":[
+        "Esch"
+    ],
+    "name:deu_x_variant":[
         "Esche"
     ],
     "name:epo_x_preferred":[
+        "Esch"
+    ],
+    "name:epo_x_variant":[
         "Esche"
     ],
     "name:est_x_preferred":[
+        "Esch"
+    ],
+    "name:est_x_variant":[
         "Esche"
     ],
     "name:eus_x_preferred":[
+        "Esch"
+    ],
+    "name:eus_x_variant":[
         "Esche"
     ],
     "name:fra_x_preferred":[
+        "Esch"
+    ],
+    "name:fra_x_variant":[
         "Esche"
     ],
     "name:hun_x_preferred":[
+        "Esch"
+    ],
+    "name:hun_x_variant":[
         "Esche"
     ],
     "name:ita_x_preferred":[
+        "Esch"
+    ],
+    "name:ita_x_variant":[
         "Esche"
     ],
-    "name:kaz_x_preferred":[
+    "name:kaz_x_variant":[
         "\u042d\u0448\u0435"
     ],
-    "name:kir_x_preferred":[
+    "name:kir_x_variant":[
         "\u042d\u0448\u0435"
     ],
     "name:lat_x_preferred":[
+        "Esch"
+    ],
+    "name:lat_x_variant":[
         "Esche"
     ],
     "name:msa_x_preferred":[
+        "Esch"
+    ],
+    "name:msa_x_variant":[
         "Esche"
     ],
     "name:nld_x_preferred":[
+        "Esch"
+    ],
+    "name:nld_x_variant":[
         "Esche"
     ],
     "name:pol_x_preferred":[
+        "Esch"
+    ],
+    "name:pol_x_variant":[
         "Esche"
     ],
     "name:por_x_preferred":[
+        "Esch"
+    ],
+    "name:por_x_variant":[
         "Esche"
     ],
     "name:ron_x_preferred":[
+        "Esch"
+    ],
+    "name:ron_x_variant":[
         "Esche"
     ],
-    "name:rus_x_preferred":[
+    "name:rus_x_variant":[
         "\u042d\u0448\u0435"
     ],
     "name:spa_x_preferred":[
+        "Esch"
+    ],
+    "name:spa_x_variant":[
         "Esche"
     ],
-    "name:srp_x_preferred":[
+    "name:srp_x_variant":[
         "\u0415\u0448\u0435"
     ],
-    "name:ukr_x_preferred":[
+    "name:ukr_x_variant":[
         "\u0415\u0448\u0435"
     ],
     "name:und_x_variant":[
         "Esch"
     ],
     "name:uzb_x_preferred":[
+        "Esch"
+    ],
+    "name:uzb_x_variant":[
         "Esche"
     ],
     "name:vie_x_preferred":[
+        "Esch"
+    ],
+    "name:vie_x_variant":[
         "Esche"
     ],
     "name:vol_x_preferred":[
+        "Esch"
+    ],
+    "name:vol_x_variant":[
         "Esche"
     ],
     "name:war_x_preferred":[
+        "Esch"
+    ],
+    "name:war_x_variant":[
         "Esche"
     ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191581,
         85633111,
-        1377685163,
-        404227541,
-        101809909,
         102063709,
+        1377685163,
+        101809909,
+        404227541,
         85682513
     ],
     "wof:breaches":[],
@@ -135,8 +192,8 @@
         }
     ],
     "wof:id":1377802597,
-    "wof:lastmodified":1566719407,
-    "wof:name":"Esche",
+    "wof:lastmodified":1689205362,
+    "wof:name":"Esch",
     "wof:parent_id":101809909,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-de",


### PR DESCRIPTION
This PR updates all of the name translations for Esch, moving the existing name translations to variant properties.

**Number of records updated**: 1